### PR TITLE
Unpin node 20.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.8.0]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20.8.0]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "(BSD-3-Clause OR LicenseRef-scancode-w3c-test-suite)",
   "engines": {
-    "node": ">=18.0"
+    "node": ">=18"
   },
   "bugs": {
     "url": "https://github.com/w3c/vc-data-model-2.0-test-suite/issues"


### PR DESCRIPTION
1. unpins test runner so it will run on the latest version of node 20
2. updates engines.node to >= 18 to match other test projects (semver.satisifies likes this pattern)