### PR TITLE
Add issuer name tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # w3c/vc-data-model-2.0-test-suite ChangeLog
 
+## 1.1.0 -
+
+### Added
+- Add new tests for `issuer.name` including Internationalization settings.
+
 ## 1.0.0 - 2023-11-10
 
 ### Added

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -317,6 +317,13 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         await assert.rejects(
           issue(require('./input/credential-issuer-object-no-id-fail.json')));
       });
+      it2('If present, the value of the "issuer.name" property MUST be a ' +
+      'string or a language value object as described in 10.1 Language and' +
+      ' Base Direction.', async function() {
+        await issue(require('./input/credential-issuer-name-ok.json'));
+        await issue(require(
+          './input/credential-issuer-name-language-en-ok.json'));
+      });
       it2('If present, the value of the validFrom property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +
         'and time the credential becomes valid, which could be a date and ' +

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -318,8 +318,8 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           issue(require('./input/credential-issuer-object-no-id-fail.json')));
       });
       it2('If present, the value of the "issuer.name" property MUST be a ' +
-      'string or a language value object as described in 10.1 Language and' +
-      ' Base Direction.', async function() {
+      'string or a language value object as described in 10.1 Language and ' +
+      'Base Direction.', async function() {
         await issue(require('./input/credential-issuer-name-ok.json'));
         await issue(require(
           './input/credential-issuer-name-language-en-ok.json'));

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -323,6 +323,12 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         await issue(require('./input/credential-issuer-name-ok.json'));
         await issue(require(
           './input/credential-issuer-name-language-en-ok.json'));
+        await issue(require(
+          './input/credential-issuer-name-language-direction-en-ok.json'));
+        await issue(require(
+          './input/credential-issuer-multi-language-name-ok.json'));
+        await assert.rejects(issue(require(
+          './input/credential-issuer-name-extra-prop-en-fail.json')));
       });
       it2('If present, the value of the validFrom property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +

--- a/tests/input/credential-issuer-multi-language-name-ok.json
+++ b/tests/input/credential-issuer-multi-language-name-ok.json
@@ -6,11 +6,17 @@
     "VerifiableCredential"
   ],
   "issuer": {
-    "id": "did:example:issuer",
-    "name": {
-      "@value":"ExampleIssuer",
+    "id": "did:issuer:dog",
+    "name": [{
+      "@value":"Dog",
       "@language": "en"
-    }
+    }, {
+      "@value":"Chien",
+      "@language": "fr"
+    }, {
+      "@value":"Cane",
+      "@language": "it"
+    }]
   },
   "credentialSubject": {
     "id": "did:example:subject"

--- a/tests/input/credential-issuer-name-extra-prop-en-fail.json
+++ b/tests/input/credential-issuer-name-extra-prop-en-fail.json
@@ -9,7 +9,8 @@
     "id": "did:example:issuer",
     "name": {
       "@value":"ExampleIssuer",
-      "@language": "en"
+      "@language": "en",
+      "url": "did:example:issuer"
     }
   },
   "credentialSubject": {

--- a/tests/input/credential-issuer-name-language-direction-en-ok.json
+++ b/tests/input/credential-issuer-name-language-direction-en-ok.json
@@ -9,7 +9,8 @@
     "id": "did:example:issuer",
     "name": {
       "@value":"ExampleIssuer",
-      "@language": "en"
+      "@language": "en",
+      "@direction": "ltr"
     }
   },
   "credentialSubject": {

--- a/tests/input/credential-issuer-name-language-en-ok.json
+++ b/tests/input/credential-issuer-name-language-en-ok.json
@@ -1,0 +1,19 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "validFrom": "2023-02-26T00:37:06Z",
+  "issuer": {
+    "id": "did:example:issuer",
+    "name": {
+      "@value":"ExampleIssuer",
+      "@language": "en"
+    }
+  },
+  "credentialSubject": {
+    "id": "did:example:subject"
+  }
+}

--- a/tests/input/credential-issuer-name-ok.json
+++ b/tests/input/credential-issuer-name-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "validFrom": "2023-02-26T00:37:06Z",
   "issuer": {
     "id": "did:example:issuer",
     "name": "ExampleIssuer"

--- a/tests/input/credential-issuer-name-ok.json
+++ b/tests/input/credential-issuer-name-ok.json
@@ -1,0 +1,16 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "validFrom": "2023-02-26T00:37:06Z",
+  "issuer": {
+    "id": "did:example:issuer",
+    "name": "ExampleIssuer"
+  },
+  "credentialSubject": {
+    "id": "did:example:subject"
+  }
+}


### PR DESCRIPTION
Adds a test for "If present, the value of the issuer.name property MUST be a string or a language value object as described in 10.1 Language and Base Direction."

1. create an invalid "value object" with an extra prop like "url"
2. create a value object array with multiple languages
3. add a test with `@direction`