### PR TITLE
Use endpoints class

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ checked):
 Implementations are expected to not error when any of the following context
 files are used in a verifiable credential or a verifiable presentation:
 
-- [VC 2.0 Context - https://www.w3.org/ns/credentials/v2](https://www.w3.org/ns/credentials/v2)
-- [VC Examples Context - https://www.w3.org/ns/credentials/examples/v2](https://www.w3.org/ns/credentials/examples/v2)
+- [Vc 2.0 Context - https://www.w3.org/ns/credentials/v2](https://www.w3.org/ns/credentials/v2)
+- [Vc Examples Context - https://www.w3.org/ns/credentials/examples/v2](https://www.w3.org/ns/credentials/examples/v2)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ checked):
 Implementations are expected to not error when any of the following context
 files are used in a verifiable credential or a verifiable presentation:
 
-- [Vc 2.0 Context - https://www.w3.org/ns/credentials/v2](https://www.w3.org/ns/credentials/v2)
-- [Vc Examples Context - https://www.w3.org/ns/credentials/examples/v2](https://www.w3.org/ns/credentials/examples/v2)
+- [VC 2.0 Context - https://www.w3.org/ns/credentials/v2](https://www.w3.org/ns/credentials/v2)
+- [VC Examples Context - https://www.w3.org/ns/credentials/examples/v2](https://www.w3.org/ns/credentials/examples/v2)
 
 ## Usage
 

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -37,7 +37,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         await fn.apply(this, arguments);
       });
     }
-    const proveOptions = {challenge};
+    const createOptions = {challenge};
     const verifyPresentationOptions = {
       checks: ['proof'],
       challenge
@@ -73,12 +73,12 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         });
       it2('Verifiable presentations MUST include a @context property.',
         async function() {
-          //FIXME reimplement this once signed VP creation via VC-API
+          //FIXME reimplement this once signed Vp creation via VC-API
           //has been finalized
           /*
-          const vp = await endpoints.proveVP({
+          const vp = await endpoints.createVp({
             presentation: require('./input/presentation-ok.json'),
-            options: proveOptions
+            options: createOptions
           });
           vp.should.have.property('@context');
           */
@@ -99,12 +99,12 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('Verifiable presentations: The value of the @context property MUST ' +
         'be an ordered set where the first item is a URL with the value ' +
         'https://www.w3.org/ns/credentials/v2.', async function() {
-        //FIXME reimplement this once signed VP creation via VC-API
+        //FIXME reimplement this once signed Vp creation via VC-API
         //has been finalized
         /*
-        const vp = await endpoints.proveVP({
+        const vp = await endpoints.createVp({
           presentation: require('./input/presentation-ok.json'),
-          options: proveOptions
+          options: createOptions
         });
         assert(Array.isArray(vp['@context']));
         assert.strictEqual(vp['@context'][0], baseContextUrl);
@@ -203,9 +203,9 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-optional-type-ok.json'));
         await assert.rejects(endpoints.issue(require(
           './input/credential-missing-required-type-fail.json')));
-        const presentationOptionalType = await endpoints.proveVP({
+        const presentationOptionalType = await endpoints.createVp({
           presentation: require('./input/presentation-optional-type-ok.json'),
-          options: proveOptions
+          options: createOptions
         });
         await endpoints.verifyVp(
           presentationOptionalType,
@@ -408,9 +408,9 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         'format.', async function() {
         //FIXME remove the internal prove once VC-API presentation
         //creation is stabilized
-        const presentationWithCredential = await endpoints.proveVP({
+        const presentationWithCredential = await endpoints.createVp({
           presentation: require('./input/presentation-vc-ok.json'),
-          options: proveOptions
+          options: createOptions
         });
         await endpoints.verifyVp(
           presentationWithCredential,
@@ -423,9 +423,9 @@ describe('Verifiable Credentials Data Model v2.0', function() {
 
         // FIXME remove internal prove once VC-API presentation
         // creation is finalized
-        const presentationWithCredentials = await endpoints.proveVP({
+        const presentationWithCredentials = await endpoints.createVp({
           presentation: require('./input/presentation-multiple-vc-ok.json'),
-          options: proveOptions
+          options: createOptions
         });
         await endpoints.verifyVp(
           presentationWithCredentials,

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -1,17 +1,12 @@
 /*!
  * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
  */
-import {
-  createRequestBody,
-  createVerifyRequestBody
-} from './mock.data.js';
-import {createTimeStamp, proveVP} from './data-generator.js';
 import assert from 'node:assert/strict';
 import {createRequire} from 'module';
+import {createTimeStamp} from './data-generator.js';
 import {filterByTag} from 'vc-api-test-suite-implementations';
-import http from 'http';
 import {randomFillSync} from 'node:crypto';
-import receiveJson from './receive-json.js';
+import {TestEndpoints} from './TestEndpoints.js';
 
 const require = createRequire(import.meta.url);
 const baseContextUrl = 'https://www.w3.org/ns/credentials/v2';
@@ -33,12 +28,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
   // the reportData will be displayed under the test title
   this.reportData = reportData;
   for(const [name, implementation] of match) {
-    const issuer = implementation.issuers.find(
-      issuer => issuer.tags.has(vcApiTag));
-    const verifier = implementation.verifiers.find(
-      verifier => verifier.tags.has(vcApiTag));
-    const vpVerifier = implementation.vpVerifiers.find(
-      vpVerifier => vpVerifier.tags.has(vcApiTag));
+    const endpoints = new TestEndpoints({implementation, tag: vcApiTag});
     function it2(title, fn) {
       it(title, async function() {
         this.test.cell = {
@@ -47,68 +37,6 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         };
         await fn.apply(this, arguments);
       });
-    }
-
-    async function post(endpoint, object) {
-      const url = endpoint.settings.endpoint;
-      if(url.startsWith('https:')) {
-        // Use vc-api-test-suite-implementations for HTTPS requests.
-        const {data, error} = await endpoint.post({json: object});
-        if(error) {
-          throw error;
-        }
-        return data;
-      }
-      const postData = Buffer.from(JSON.stringify(object));
-      const res = await new Promise((resolve, reject) => {
-        const req = http.request(url, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Content-Length': postData.length,
-            Accept: 'application/json'
-          }
-        }, resolve);
-        req.on('error', reject);
-        req.end(postData);
-      });
-      const result = await receiveJson(res);
-      if(res.statusCode >= 400) {
-        if(result != null && result.errors) {
-          throw new Error(result.errors);
-        }
-        throw new Error(result);
-      }
-      if(res.statusCode >= 300) {
-        throw new Error('Redirect not supported');
-      }
-      return result;
-    }
-
-    async function issue(credential) {
-      const issueBody = createRequestBody({issuer, vc: credential});
-      return post(issuer, issueBody);
-    }
-
-    async function verify(vc) {
-      const verifyBody = createVerifyRequestBody({vc});
-      const result = await post(verifier, verifyBody);
-      if(result?.errors?.length) {
-        throw result.errors[0];
-      }
-      return result;
-    }
-
-    async function verifyVp(vp, options = {checks: []}) {
-      const body = {
-        verifiablePresentation: vp,
-        options
-      };
-      const result = await post(vpVerifier, body);
-      if(result?.errors?.length) {
-        throw result.errors[0];
-      }
-      return result;
     }
     // use base64 encoded 128 bit number as the challenge
     const buf = Buffer.alloc(16); // 128 bits
@@ -134,16 +62,16 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         const doc = {
           type: ['NonconformingDocument']
         };
-        await assert.rejects(verify(doc));
-        await assert.rejects(verifyVp(doc));
+        await assert.rejects(endpoints.verify(doc));
+        await assert.rejects(endpoints.verifyVp(doc));
       });
       it2('Verifiable credentials MUST include a @context property.',
         async function() {
           // positive @context test
-          const vc = await issue(require('./input/credential-ok.json'));
+          const vc = await endpoints.issue(require('./input/credential-ok.json'));
           vc.should.have.property('@context');
           // negative @context test
-          await assert.rejects(issue(
+          await assert.rejects(endpoints.issue(
             require('./input/credential-no-context-fail.json')));
         });
       it2('Verifiable presentations MUST include a @context property.',
@@ -151,24 +79,24 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           //FIXME reimplement this once signed VP creation via VC-API
           //has been finalized
           /*
-          const vp = await proveVP({
+          const vp = await endpoints.proveVP({
             presentation: require('./input/presentation-ok.json'),
             options: proveOptions
           });
           vp.should.have.property('@context');
           */
-          await assert.rejects(verifyVp(
+          await assert.rejects(endpoints.verifyVp(
             require('./input/presentation-no-context-fail.json')));
         });
       it2('Verifiable credentials: The value of the @context property MUST ' +
         'be an ordered set where the first item is a URL with the value ' +
         'https://www.w3.org/ns/credentials/v2.', async function() {
         //positive issue test
-        const vc = await issue(require('./input/credential-ok.json'));
+        const vc = await endpoints.issue(require('./input/credential-ok.json'));
         assert(Array.isArray(vc['@context']));
         assert.strictEqual(vc['@context'][0], baseContextUrl);
         // negative issue test
-        await assert.rejects(issue(
+        await assert.rejects(endpoints.issue(
           require('./input/credential-missing-base-context-fail.json')));
       });
       it2('Verifiable presentations: The value of the @context property MUST ' +
@@ -177,82 +105,82 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         //FIXME reimplement this once signed VP creation via VC-API
         //has been finalized
         /*
-        const vp = await proveVP({
+        const vp = await endpoints.proveVP({
           presentation: require('./input/presentation-ok.json'),
           options: proveOptions
         });
         assert(Array.isArray(vp['@context']));
         assert.strictEqual(vp['@context'][0], baseContextUrl);
         */
-        await assert.rejects(verifyVp(
+        await assert.rejects(endpoints.verifyVp(
           require('./input/presentation-missing-base-context-fail.json')));
       });
       it2('Verifiable credential @context: "Subsequent items in the array ' +
         'MUST be composed of any combination of URLs and/or objects where ' +
         'each is processable as a JSON-LD Context."', async function() {
-        await issue(require('./input/credential-context-combo1-ok.json'));
-        await issue(require('./input/credential-context-combo2-ok.json'));
+        await endpoints.issue(require('./input/credential-context-combo1-ok.json'));
+        await endpoints.issue(require('./input/credential-context-combo2-ok.json'));
         await assert.rejects(
-          issue(require('./input/credential-context-combo3-fail.json')));
+          endpoints.issue(require('./input/credential-context-combo3-fail.json')));
         await assert.rejects(
-          issue(require('./input/credential-context-combo4-fail.json')));
+          endpoints.issue(require('./input/credential-context-combo4-fail.json')));
       });
       it2('if present: "The id property MUST express an identifier that ' +
         'others are expected to use when expressing statements about a ' +
         'specific thing identified by that identifier."', async function() {
-        await issue(require('./input/credential-id-other-ok.json'));
+        await endpoints.issue(require('./input/credential-id-other-ok.json'));
         await assert.rejects(
-          issue(require('./input/credential-id-nonidentifier-fail.json')));
+          endpoints.issue(require('./input/credential-id-nonidentifier-fail.json')));
       });
       it2('if present: "The id property MUST NOT have more than one value."',
         async function() {
-          await issue(require('./input/credential-single-id-ok.json'));
-          await issue(require('./input/credential-subject-single-id-ok.json'));
+          await endpoints.issue(require('./input/credential-single-id-ok.json'));
+          await endpoints.issue(require('./input/credential-subject-single-id-ok.json'));
           await assert.rejects(
-            issue(require('./input/credential-multi-id-fail.json')));
+            endpoints.issue(require('./input/credential-multi-id-fail.json')));
           await assert.rejects(
-            issue(require('./input/credential-subject-multi-id-fail.json')));
+            endpoints.issue(require('./input/credential-subject-multi-id-fail.json')));
         });
       it2('if present: "The value of the id property MUST be a URL which ' +
         'MAY be dereferenced."', async function() {
         await assert.rejects(
-          issue(require('./input/credential-not-url-id-fail.json')));
+          endpoints.issue(require('./input/credential-not-url-id-fail.json')));
       });
       it2('The value of the id property MUST be a single URL.',
         async function() {
           await assert.rejects(
-            issue(require('./input/credential-nonsingle-id-fail.json')));
+            endpoints.issue(require('./input/credential-nonsingle-id-fail.json')));
         });
       it2('Verifiable credentials MUST have a type property.',
         async function() {
           await assert.rejects(
-            issue(require('./input/credential-no-type-fail.json')));
+            endpoints.issue(require('./input/credential-no-type-fail.json')));
         });
       it2('Verifiable presentations MUST have a type property.',
         async function() {
           await assert.rejects(
-            verifyVp(require('./input/presentation-no-type-fail.json')));
+            endpoints.verifyVp(require('./input/presentation-no-type-fail.json')));
         });
       it2('The value of the type property MUST be, or map to (through ' +
         'interpretation of the @context property), one or more URLs.',
       async function() {
         // type is URL: OK
-        await issue(require('./input/credential-type-url-ok.json'));
+        await endpoints.issue(require('./input/credential-type-url-ok.json'));
         // type mapping to URL: OK
-        await issue(require('./input/credential-type-mapped-url-ok.json'));
+        await endpoints.issue(require('./input/credential-type-mapped-url-ok.json'));
         // type mapped not to URL: fail
         await assert.rejects(
-          issue(require('./input/credential-type-mapped-nonurl-fail.json')));
+          endpoints.issue(require('./input/credential-type-mapped-nonurl-fail.json')));
         // type not mapped: fail
         await assert.rejects(
-          issue(require('./input/credential-type-unmapped-fail.json')));
+          endpoints.issue(require('./input/credential-type-unmapped-fail.json')));
       });
       it2('type property: "If more than one URL is provided, the URLs ' +
         'MUST be interpreted as an unordered set."', async function() {
         //issue VC with multiple urls in type property
-        await issue(require('./input/credential-type-urls-order-1-ok.json'));
+        await endpoints.issue(require('./input/credential-type-urls-order-1-ok.json'));
         //issue another VC with same urls in a different order
-        await issue(require('./input/credential-type-urls-order-2-ok.json'));
+        await endpoints.issue(require('./input/credential-type-urls-order-2-ok.json'));
       });
       // FIXME this needs to be expanded into at least 6 different tests
       // Verifiable Credential MUST have a type specified
@@ -266,35 +194,35 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // (Verifiable) presentation requires type VerifiablePresentation
         // Additional (more specific) types for these are optional.
         // Missing type property is tested separately.
-        await issue(require('./input/credential-optional-type-ok.json'));
+        await endpoints.issue(require('./input/credential-optional-type-ok.json'));
         await assert.rejects(
-          issue(require('./input/credential-missing-required-type-fail.json')));
-        const presentationOptionalType = await proveVP({
+          endpoints.issue(require('./input/credential-missing-required-type-fail.json')));
+        const presentationOptionalType = await endpoints.proveVP({
           presentation: require('./input/presentation-optional-type-ok.json'),
           options: proveOptions
         });
-        await verifyVp(presentationOptionalType, verifyPresentationOptions);
+        await endpoints.verifyVp(presentationOptionalType, verifyPresentationOptions);
         await assert.rejects(
-          verifyVp(require(
+          endpoints.verifyVp(require(
             './input/presentation-missing-required-type-fail.json')));
 
         // Other objects requiring type: proof, credentialStatus, termsOfUse,
         // and evidence.
         // Note: testing proof requires the issuer to allow the input
         // credential to have an existing proof property.
-        await issue(require('./input/credential-proof-ok.json'));
+        await endpoints.issue(require('./input/credential-proof-ok.json'));
         await assert.rejects(
-          verify(require('./input/credential-proof-missing-type-fail.json')));
-        await issue(require('./input/credential-status-ok.json'));
+          endpoints.verify(require('./input/credential-proof-missing-type-fail.json')));
+        await endpoints.issue(require('./input/credential-status-ok.json'));
         await assert.rejects(
-          issue(require('./input/credential-status-missing-type-fail.json')));
-        await issue(require('./input/credential-termsofuse-ok.json'));
+          endpoints.issue(require('./input/credential-status-missing-type-fail.json')));
+        await endpoints.issue(require('./input/credential-termsofuse-ok.json'));
         await assert.rejects(
-          issue(require(
+          endpoints.issue(require(
             './input/credential-termsofuse-missing-type-fail.json')));
-        await issue(require('./input/credential-evidence-ok.json'));
+        await endpoints.issue(require('./input/credential-evidence-ok.json'));
         await assert.rejects(
-          issue(require('./input/credential-evidence-missing-type-fail.json')));
+          endpoints.issue(require('./input/credential-evidence-missing-type-fail.json')));
       });
       it.skip('All credentials, presentations, and encapsulated objects ' +
         'SHOULD specify, or be associated with, additional more narrow types ' +
@@ -305,84 +233,84 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('A verifiable credential MUST have a credentialSubject property.',
         async function() {
           await assert.rejects(
-            issue(require('./input/credential-no-subject-fail.json')));
+            endpoints.issue(require('./input/credential-no-subject-fail.json')));
         });
       it2('The value of the credentialSubject property is defined as a set ' +
         'of objects where each object MUST be the subject of one or more ' +
         'claims, which MUST be serialized inside the credentialSubject ' +
         'property.', async function() {
         await assert.rejects(
-          issue(require('./input/credential-subject-no-claims-fail.json')));
-        await issue(require('./input/credential-subject-multiple-ok.json'));
+          endpoints.issue(require('./input/credential-subject-no-claims-fail.json')));
+        await endpoints.issue(require('./input/credential-subject-multiple-ok.json'));
         await assert.rejects(
-          issue(require(
+          endpoints.issue(require(
             './input/credential-subject-multiple-empty-fail.json')));
       });
       it2('A verifiable credential MUST have an issuer property.',
         async function() {
           await assert.rejects(
-            issue(require('./input/credential-no-issuer-fail.json')));
+            endpoints.issue(require('./input/credential-no-issuer-fail.json')));
         });
       it2('The value of the issuer property MUST be either a URL, or an ' +
         'object containing an id property whose value is a URL.',
       async function() {
-        await issue(require('./input/credential-issuer-object-ok.json'));
-        await issue(require('./input/credential-issuer-url-ok.json'));
+        await endpoints.issue(require('./input/credential-issuer-object-ok.json'));
+        await endpoints.issue(require('./input/credential-issuer-url-ok.json'));
         await assert.rejects(
-          issue(require('./input/credential-issuer-nonurl-fail.json')));
+          endpoints.issue(require('./input/credential-issuer-nonurl-fail.json')));
         await assert.rejects(
-          issue(require('./input/credential-issuer-object-no-id-fail.json')));
-        await assert.rejects(issue(require(
+          endpoints.issue(require('./input/credential-issuer-object-no-id-fail.json')));
+        await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-object-id-not-url-fail.json')));
       });
       it2('If present, the value of the "issuer.name" property MUST be a ' +
         'string or a language value object as described in 10.1 Language and ' +
         'Base Direction.', async function() {
-        await issue(require('./input/credential-issuer-name-ok.json'));
-        await issue(require(
+        await endpoints.issue(require('./input/credential-issuer-name-ok.json'));
+        await endpoints.issue(require(
           './input/credential-issuer-name-optional-ok.json'));
-        await issue(require(
+        await endpoints.issue(require(
           './input/credential-issuer-name-language-en-ok.json'));
-        await issue(require(
+        await endpoints.issue(require(
           './input/credential-issuer-name-language-direction-en-ok.json'));
-        await issue(require(
+        await endpoints.issue(require(
           './input/credential-issuer-multi-language-name-ok.json'));
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-name-extra-prop-en-fail.json')));
       });
       it2('If present, the value of the "issuer.description" property ' +
         'MUST be a string or a language value object as described in 10.1 ' +
         'Language and Base Direction.', async function() {
-        await issue(require('./input/credential-issuer-description-ok.json'));
-        await issue(require(
+        await endpoints.issue(require('./input/credential-issuer-description-ok.json'));
+        await endpoints.issue(require(
           './input/credential-issuer-description-optional-ok.json'));
-        await issue(require(
+        await endpoints.issue(require(
           './input/credential-issuer-description-language-en-ok.json'));
-        await issue(require('./input/credential-issuer-description-language-' +
+        await endpoints.issue(require('./input/credential-issuer-description-language-' +
           'direction-en-ok.json'));
-        await issue(require(
+        await endpoints.issue(require(
           './input/credential-issuer-multi-language-description-ok.json'));
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-description-extra-prop-en-fail.json')));
       });
       it2('If present, the value of the validFrom property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +
         'and time the credential becomes valid, which could be a date and ' +
         'time in the future.', async function() {
-        await issue(require('./input/credential-validfrom-ms-ok.json'));
-        await issue(require('./input/credential-validfrom-tz-ok.json'));
+        await endpoints.issue(require('./input/credential-validfrom-ms-ok.json'));
+        await endpoints.issue(require('./input/credential-validfrom-tz-ok.json'));
         await assert.rejects(
-          issue(require('./input/credential-validfrom-invalid-fail.json')));
+          endpoints.issue(require('./input/credential-validfrom-invalid-fail.json')));
       });
       it2('If present, the value of the validUntil property MUST be a ' +
         'string value of an [XMLSCHEMA11-2] combined date-time string ' +
         'representing the date and time the credential ceases to be valid, ' +
         'which could be a date and time in the past.', async function() {
-        await issue(require('./input/credential-validuntil-ok.json'));
-        await issue(require('./input/credential-validuntil-ms-ok.json'));
-        await issue(require('./input/credential-validuntil-tz-ok.json'));
+        await endpoints.issue(require('./input/credential-validuntil-ok.json'));
+        await endpoints.issue(require('./input/credential-validuntil-ms-ok.json'));
+        await endpoints.issue(require('./input/credential-validuntil-tz-ok.json'));
         await assert.rejects(
-          issue(require('./input/credential-validuntil-invalid-fail.json')));
+          endpoints.issue(require('./input/credential-validuntil-invalid-fail.json')));
       });
       it2('If a validUntil value also exists, the validFrom value MUST ' +
         'express a datetime that is temporally the same or earlier than the ' +
@@ -391,7 +319,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-validUntil-validFrom-ok.json');
         positiveTest.validFrom = createTimeStamp({skew: -2});
         positiveTest.validUntil = createTimeStamp({skew: 2});
-        await issue(positiveTest);
+        await endpoints.issue(positiveTest);
         const negativeTest = require(
           './input/credential-validUntil-validFrom-fail.json');
         negativeTest.validFrom = createTimeStamp({skew: 2});
@@ -399,14 +327,14 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         let error;
         let result;
         try {
-          result = await issue(negativeTest);
+          result = await endpoints.issue(negativeTest);
         } catch(e) {
           error = e;
         }
         if(error) {
           return;
         }
-        assert.rejects(verify(result));
+        assert.rejects(endpoints.verify(result));
       });
       it2('If a validFrom value also exists, the validUntil value MUST ' +
         'express a datetime that is temporally the same or later than the ' +
@@ -415,7 +343,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-validUntil-validFrom-ok.json');
         positiveTest.validFrom = createTimeStamp({skew: -2});
         positiveTest.validUntil = createTimeStamp({skew: 2});
-        await issue(positiveTest);
+        await endpoints.issue(positiveTest);
         const negativeTest = require(
           './input/credential-validUntil-validFrom-fail.json');
         negativeTest.validFrom = createTimeStamp({skew: 2});
@@ -423,14 +351,14 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         let error;
         let result;
         try {
-          result = await issue(negativeTest);
+          result = await endpoints.issue(negativeTest);
         } catch(e) {
           error = e;
         }
         if(error) {
           return;
         }
-        assert.rejects(verify(result));
+        assert.rejects(endpoints.verify(result));
       });
       // FIXME remove as this doesn't seem to be in the spec
       it.skip('At least one proof mechanism, and the details necessary ' +
@@ -450,12 +378,12 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         'MUST include id and type.', async function() {
         // type requirement is tested elsewhere
         await assert.rejects(
-          issue(require('./input/credential-status-missing-id-fail.json')));
+          endpoints.issue(require('./input/credential-status-missing-id-fail.json')));
       });
       it2('credentialStatus id property MUST be a URL which MAY be ' +
         'dereferenced.', async function() {
         await assert.rejects(
-          issue(require('./input/credential-status-nonurl-id-fail.json')));
+          endpoints.issue(require('./input/credential-status-nonurl-id-fail.json')));
       });
       it2('In Verifiable Presentations, the verifiableCredential property ' +
         'MAY be present. The value MUST be an array of one or more ' +
@@ -463,25 +391,25 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         'format.', async function() {
         //FIXME remove the internal prove once VC-API presentation
         //creation is stabilized
-        const presentationWithCredential = await proveVP({
+        const presentationWithCredential = await endpoints.proveVP({
           presentation: require('./input/presentation-vc-ok.json'),
           options: proveOptions
         });
-        await verifyVp(presentationWithCredential, verifyPresentationOptions);
+        await endpoints.verifyVp(presentationWithCredential, verifyPresentationOptions);
         // FIXME support for derived VCs is not standard yet
         // and probably will be its own test suite
-        //await verifyVp(require('./input/presentation-derived-vc-ok.json'));
+        //await endpoints.verifyVp(require('./input/presentation-derived-vc-ok.json'));
 
         // FIXME remove internal prove once VC-API presentation
         // creation is finalized
-        const presentationWithCredentials = await proveVP({
+        const presentationWithCredentials = await endpoints.proveVP({
           presentation: require('./input/presentation-multiple-vc-ok.json'),
           options: proveOptions
         });
-        await verifyVp(presentationWithCredentials, verifyPresentationOptions);
-        await assert.rejects(verifyVp(require(
+        await endpoints.verifyVp(presentationWithCredentials, verifyPresentationOptions);
+        await assert.rejects(endpoints.verifyVp(require(
           './input/presentation-vc-missing-required-type-fail.json')));
-        await assert.rejects(verifyVp(require(
+        await assert.rejects(endpoints.verifyVp(require(
           './input/presentation-derived-vc-missing-required-type-fail.json')));
       });
 
@@ -489,63 +417,63 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('JSON-LD-based processors MUST produce an error when a JSON-LD ' +
         'context redefines any term in the active context.', async function() {
         // This depends on "@protected" (which is used for the base context).
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-redef-type-fail.json')));
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-redef-type2-fail.json')));
       });
       it2('The value of the credentialSchema property MUST be one or more ' +
         'data schemas that provide verifiers with enough information to ' +
         'determine whether the provided data conforms to the provided ' +
         'schema(s).', async function() {
-        await issue(require('./input/credential-schema-ok.json'));
-        await issue(require('./input/credential-schemas-ok.json'));
+        await endpoints.issue(require('./input/credential-schema-ok.json'));
+        await endpoints.issue(require('./input/credential-schemas-ok.json'));
       });
       it2('Each credentialSchema MUST specify its type (for example, ' +
         'JsonSchemaValidator2018), and an id property.', async function() {
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-schema-no-type-fail.json')));
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-schema-no-id-fail.json')));
       });
       it2('credentialSchema id MUST be a URL identifying the schema file.',
         async function() {
-          await assert.rejects(issue(require(
+          await assert.rejects(endpoints.issue(require(
             './input/credential-schema-non-url-id-fail.json')));
         });
       it.skip('The value of the refreshService property MUST be one or more ' +
         'refresh services that provides enough information to the ' +
         'recipient\'s software such that the recipient can refresh the ' +
         'verifiable credential.', async function() {
-        await issue(require('./input/credential-refresh-ok.json'));
-        await issue(require('./input/credential-refreshs-ok.json'));
+        await endpoints.issue(require('./input/credential-refresh-ok.json'));
+        await endpoints.issue(require('./input/credential-refreshs-ok.json'));
       });
       it.skip('Each refreshService value MUST specify its type (for example, ' +
         'ManualRefreshService2018) and its id, which is the URL of the ' +
         'service.', async function() {
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-refresh-no-type-fail.json')));
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-refresh-no-id-fail.json')));
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-refresh-non-url-id-fail.json')));
       });
       it2('The value of the termsOfUse property MUST specify one or more ' +
         'terms of use policies under which the creator issued the credential ' +
         'or presentation.', async function() {
-        await issue(require('./input/credential-termsofuses-ok.json'));
+        await endpoints.issue(require('./input/credential-termsofuses-ok.json'));
       });
       it2('Each termsOfUse value MUST specify its type, for example, ' +
         'IssuerPolicy, and MAY specify its instance id.', async function() {
-        await assert.rejects(issue(require(
+        await assert.rejects(endpoints.issue(require(
           './input/credential-termsofuse-no-type-fail.json')));
-        await issue(require('./input/credential-termsofuse-id-ok.json'));
+        await endpoints.issue(require('./input/credential-termsofuse-id-ok.json'));
       });
       it2('The value of the evidence property MUST be one or more evidence ' +
         'schemes providing enough information for a verifier to determine ' +
         'whether the evidence gathered by the issuer meets its confidence ' +
         'requirements for relying on the credential.', async function() {
-        await issue(require('./input/credential-evidences-ok.json'));
+        await endpoints.issue(require('./input/credential-evidences-ok.json'));
       });
       it.skip('(ZKP) The verifiable credential MUST contain a Proof, using ' +
         'the proof property, so that the holder can derive a verifiable ' +

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -1,11 +1,10 @@
 /*!
  * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
  */
+import {challenge, createTimeStamp} from './data-generator.js';
 import assert from 'node:assert/strict';
 import {createRequire} from 'module';
-import {createTimeStamp} from './data-generator.js';
 import {filterByTag} from 'vc-api-test-suite-implementations';
-import {randomFillSync} from 'node:crypto';
 import {TestEndpoints} from './TestEndpoints.js';
 
 const require = createRequire(import.meta.url);
@@ -38,9 +37,6 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         await fn.apply(this, arguments);
       });
     }
-    // use base64 encoded 128 bit number as the challenge
-    const buf = Buffer.alloc(16); // 128 bits
-    const challenge = 'u' + randomFillSync(buf).toString('base64url');
     const proveOptions = {challenge};
     const verifyPresentationOptions = {
       checks: ['proof'],

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -73,7 +73,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         });
       it2('Verifiable presentations MUST include a @context property.',
         async function() {
-          //FIXME reimplement this once signed Vp creation via VC-API
+          //FIXME reimplement this once signed VP creation via VC-API
           //has been finalized
           /*
           const vp = await endpoints.createVp({
@@ -99,7 +99,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('Verifiable presentations: The value of the @context property MUST ' +
         'be an ordered set where the first item is a URL with the value ' +
         'https://www.w3.org/ns/credentials/v2.', async function() {
-        //FIXME reimplement this once signed Vp creation via VC-API
+        //FIXME reimplement this once signed VP creation via VC-API
         //has been finalized
         /*
         const vp = await endpoints.createVp({
@@ -180,10 +180,10 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       });
       it2('type property: "If more than one URL is provided, the URLs ' +
         'MUST be interpreted as an unordered set."', async function() {
-        //issue Vc with multiple urls in type property
+        //issue VC with multiple urls in type property
         await endpoints.issue(require(
           './input/credential-type-urls-order-1-ok.json'));
-        //issue another Vc with same urls in a different order
+        //issue another VC with same urls in a different order
         await endpoints.issue(require(
           './input/credential-type-urls-order-2-ok.json'));
       });
@@ -416,7 +416,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           presentationWithCredential,
           verifyPresentationOptions
         );
-        // FIXME support for derived Vcs is not standard yet
+        // FIXME support for derived VCs is not standard yet
         // and probably will be its own test suite
         //await endpoints.verifyVp(require(
         //  './input/presentation-derived-vc-ok.json'));

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -68,7 +68,8 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('Verifiable credentials MUST include a @context property.',
         async function() {
           // positive @context test
-          const vc = await endpoints.issue(require('./input/credential-ok.json'));
+          const vc = await endpoints.issue(require(
+            './input/credential-ok.json'));
           vc.should.have.property('@context');
           // negative @context test
           await assert.rejects(endpoints.issue(
@@ -118,28 +119,33 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('Verifiable credential @context: "Subsequent items in the array ' +
         'MUST be composed of any combination of URLs and/or objects where ' +
         'each is processable as a JSON-LD Context."', async function() {
-        await endpoints.issue(require('./input/credential-context-combo1-ok.json'));
-        await endpoints.issue(require('./input/credential-context-combo2-ok.json'));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-context-combo3-fail.json')));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-context-combo4-fail.json')));
+        await endpoints.issue(require(
+          './input/credential-context-combo1-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-context-combo2-ok.json'));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-context-combo3-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-context-combo4-fail.json')));
       });
       it2('if present: "The id property MUST express an identifier that ' +
         'others are expected to use when expressing statements about a ' +
         'specific thing identified by that identifier."', async function() {
         await endpoints.issue(require('./input/credential-id-other-ok.json'));
         await assert.rejects(
-          endpoints.issue(require('./input/credential-id-nonidentifier-fail.json')));
+          endpoints.issue(require(
+            './input/credential-id-nonidentifier-fail.json')));
       });
       it2('if present: "The id property MUST NOT have more than one value."',
         async function() {
-          await endpoints.issue(require('./input/credential-single-id-ok.json'));
-          await endpoints.issue(require('./input/credential-subject-single-id-ok.json'));
-          await assert.rejects(
-            endpoints.issue(require('./input/credential-multi-id-fail.json')));
-          await assert.rejects(
-            endpoints.issue(require('./input/credential-subject-multi-id-fail.json')));
+          await endpoints.issue(require(
+            './input/credential-single-id-ok.json'));
+          await endpoints.issue(require(
+            './input/credential-subject-single-id-ok.json'));
+          await assert.rejects(endpoints.issue(require(
+            './input/credential-multi-id-fail.json')));
+          await assert.rejects(endpoints.issue(require(
+            './input/credential-subject-multi-id-fail.json')));
         });
       it2('if present: "The value of the id property MUST be a URL which ' +
         'MAY be dereferenced."', async function() {
@@ -148,8 +154,8 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       });
       it2('The value of the id property MUST be a single URL.',
         async function() {
-          await assert.rejects(
-            endpoints.issue(require('./input/credential-nonsingle-id-fail.json')));
+          await assert.rejects(endpoints.issue(require(
+            './input/credential-nonsingle-id-fail.json')));
         });
       it2('Verifiable credentials MUST have a type property.',
         async function() {
@@ -158,8 +164,8 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         });
       it2('Verifiable presentations MUST have a type property.',
         async function() {
-          await assert.rejects(
-            endpoints.verifyVp(require('./input/presentation-no-type-fail.json')));
+          await assert.rejects(endpoints.verifyVp(require(
+            './input/presentation-no-type-fail.json')));
         });
       it2('The value of the type property MUST be, or map to (through ' +
         'interpretation of the @context property), one or more URLs.',
@@ -167,20 +173,23 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // type is URL: OK
         await endpoints.issue(require('./input/credential-type-url-ok.json'));
         // type mapping to URL: OK
-        await endpoints.issue(require('./input/credential-type-mapped-url-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-type-mapped-url-ok.json'));
         // type mapped not to URL: fail
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-type-mapped-nonurl-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-type-mapped-nonurl-fail.json')));
         // type not mapped: fail
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-type-unmapped-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-type-unmapped-fail.json')));
       });
       it2('type property: "If more than one URL is provided, the URLs ' +
         'MUST be interpreted as an unordered set."', async function() {
         //issue VC with multiple urls in type property
-        await endpoints.issue(require('./input/credential-type-urls-order-1-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-type-urls-order-1-ok.json'));
         //issue another VC with same urls in a different order
-        await endpoints.issue(require('./input/credential-type-urls-order-2-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-type-urls-order-2-ok.json'));
       });
       // FIXME this needs to be expanded into at least 6 different tests
       // Verifiable Credential MUST have a type specified
@@ -194,14 +203,18 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // (Verifiable) presentation requires type VerifiablePresentation
         // Additional (more specific) types for these are optional.
         // Missing type property is tested separately.
-        await endpoints.issue(require('./input/credential-optional-type-ok.json'));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-missing-required-type-fail.json')));
+        await endpoints.issue(require(
+          './input/credential-optional-type-ok.json'));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-missing-required-type-fail.json')));
         const presentationOptionalType = await endpoints.proveVP({
           presentation: require('./input/presentation-optional-type-ok.json'),
           options: proveOptions
         });
-        await endpoints.verifyVp(presentationOptionalType, verifyPresentationOptions);
+        await endpoints.verifyVp(
+          presentationOptionalType,
+          verifyPresentationOptions
+        );
         await assert.rejects(
           endpoints.verifyVp(require(
             './input/presentation-missing-required-type-fail.json')));
@@ -211,18 +224,17 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // Note: testing proof requires the issuer to allow the input
         // credential to have an existing proof property.
         await endpoints.issue(require('./input/credential-proof-ok.json'));
-        await assert.rejects(
-          endpoints.verify(require('./input/credential-proof-missing-type-fail.json')));
+        await assert.rejects(endpoints.verify(require(
+          './input/credential-proof-missing-type-fail.json')));
         await endpoints.issue(require('./input/credential-status-ok.json'));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-status-missing-type-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-status-missing-type-fail.json')));
         await endpoints.issue(require('./input/credential-termsofuse-ok.json'));
-        await assert.rejects(
-          endpoints.issue(require(
-            './input/credential-termsofuse-missing-type-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-termsofuse-missing-type-fail.json')));
         await endpoints.issue(require('./input/credential-evidence-ok.json'));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-evidence-missing-type-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-evidence-missing-type-fail.json')));
       });
       it.skip('All credentials, presentations, and encapsulated objects ' +
         'SHOULD specify, or be associated with, additional more narrow types ' +
@@ -232,16 +244,17 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       });
       it2('A verifiable credential MUST have a credentialSubject property.',
         async function() {
-          await assert.rejects(
-            endpoints.issue(require('./input/credential-no-subject-fail.json')));
+          await assert.rejects(endpoints.issue(require(
+            './input/credential-no-subject-fail.json')));
         });
       it2('The value of the credentialSubject property is defined as a set ' +
         'of objects where each object MUST be the subject of one or more ' +
         'claims, which MUST be serialized inside the credentialSubject ' +
         'property.', async function() {
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-subject-no-claims-fail.json')));
-        await endpoints.issue(require('./input/credential-subject-multiple-ok.json'));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-subject-no-claims-fail.json')));
+        await endpoints.issue(require(
+          './input/credential-subject-multiple-ok.json'));
         await assert.rejects(
           endpoints.issue(require(
             './input/credential-subject-multiple-empty-fail.json')));
@@ -254,19 +267,21 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('The value of the issuer property MUST be either a URL, or an ' +
         'object containing an id property whose value is a URL.',
       async function() {
-        await endpoints.issue(require('./input/credential-issuer-object-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-issuer-object-ok.json'));
         await endpoints.issue(require('./input/credential-issuer-url-ok.json'));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-issuer-nonurl-fail.json')));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-issuer-object-no-id-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-issuer-nonurl-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-issuer-object-no-id-fail.json')));
         await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-object-id-not-url-fail.json')));
       });
       it2('If present, the value of the "issuer.name" property MUST be a ' +
         'string or a language value object as described in 10.1 Language and ' +
         'Base Direction.', async function() {
-        await endpoints.issue(require('./input/credential-issuer-name-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-issuer-name-ok.json'));
         await endpoints.issue(require(
           './input/credential-issuer-name-optional-ok.json'));
         await endpoints.issue(require(
@@ -281,12 +296,14 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('If present, the value of the "issuer.description" property ' +
         'MUST be a string or a language value object as described in 10.1 ' +
         'Language and Base Direction.', async function() {
-        await endpoints.issue(require('./input/credential-issuer-description-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-issuer-description-ok.json'));
         await endpoints.issue(require(
           './input/credential-issuer-description-optional-ok.json'));
         await endpoints.issue(require(
           './input/credential-issuer-description-language-en-ok.json'));
-        await endpoints.issue(require('./input/credential-issuer-description-language-' +
+        await endpoints.issue(require(
+          './input/credential-issuer-description-language-' +
           'direction-en-ok.json'));
         await endpoints.issue(require(
           './input/credential-issuer-multi-language-description-ok.json'));
@@ -297,20 +314,24 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +
         'and time the credential becomes valid, which could be a date and ' +
         'time in the future.', async function() {
-        await endpoints.issue(require('./input/credential-validfrom-ms-ok.json'));
-        await endpoints.issue(require('./input/credential-validfrom-tz-ok.json'));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-validfrom-invalid-fail.json')));
+        await endpoints.issue(require(
+          './input/credential-validfrom-ms-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-validfrom-tz-ok.json'));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-validfrom-invalid-fail.json')));
       });
       it2('If present, the value of the validUntil property MUST be a ' +
         'string value of an [XMLSCHEMA11-2] combined date-time string ' +
         'representing the date and time the credential ceases to be valid, ' +
         'which could be a date and time in the past.', async function() {
         await endpoints.issue(require('./input/credential-validuntil-ok.json'));
-        await endpoints.issue(require('./input/credential-validuntil-ms-ok.json'));
-        await endpoints.issue(require('./input/credential-validuntil-tz-ok.json'));
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-validuntil-invalid-fail.json')));
+        await endpoints.issue(require(
+          './input/credential-validuntil-ms-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-validuntil-tz-ok.json'));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-validuntil-invalid-fail.json')));
       });
       it2('If a validUntil value also exists, the validFrom value MUST ' +
         'express a datetime that is temporally the same or earlier than the ' +
@@ -377,13 +398,13 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('If present, the value of the credentialStatus property ' +
         'MUST include id and type.', async function() {
         // type requirement is tested elsewhere
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-status-missing-id-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-status-missing-id-fail.json')));
       });
       it2('credentialStatus id property MUST be a URL which MAY be ' +
         'dereferenced.', async function() {
-        await assert.rejects(
-          endpoints.issue(require('./input/credential-status-nonurl-id-fail.json')));
+        await assert.rejects(endpoints.issue(require(
+          './input/credential-status-nonurl-id-fail.json')));
       });
       it2('In Verifiable Presentations, the verifiableCredential property ' +
         'MAY be present. The value MUST be an array of one or more ' +
@@ -395,10 +416,14 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           presentation: require('./input/presentation-vc-ok.json'),
           options: proveOptions
         });
-        await endpoints.verifyVp(presentationWithCredential, verifyPresentationOptions);
+        await endpoints.verifyVp(
+          presentationWithCredential,
+          verifyPresentationOptions
+        );
         // FIXME support for derived VCs is not standard yet
         // and probably will be its own test suite
-        //await endpoints.verifyVp(require('./input/presentation-derived-vc-ok.json'));
+        //await endpoints.verifyVp(require(
+        //  './input/presentation-derived-vc-ok.json'));
 
         // FIXME remove internal prove once VC-API presentation
         // creation is finalized
@@ -406,7 +431,10 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           presentation: require('./input/presentation-multiple-vc-ok.json'),
           options: proveOptions
         });
-        await endpoints.verifyVp(presentationWithCredentials, verifyPresentationOptions);
+        await endpoints.verifyVp(
+          presentationWithCredentials,
+          verifyPresentationOptions
+        );
         await assert.rejects(endpoints.verifyVp(require(
           './input/presentation-vc-missing-required-type-fail.json')));
         await assert.rejects(endpoints.verifyVp(require(
@@ -461,13 +489,15 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       it2('The value of the termsOfUse property MUST specify one or more ' +
         'terms of use policies under which the creator issued the credential ' +
         'or presentation.', async function() {
-        await endpoints.issue(require('./input/credential-termsofuses-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-termsofuses-ok.json'));
       });
       it2('Each termsOfUse value MUST specify its type, for example, ' +
         'IssuerPolicy, and MAY specify its instance id.', async function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-termsofuse-no-type-fail.json')));
-        await endpoints.issue(require('./input/credential-termsofuse-id-ok.json'));
+        await endpoints.issue(require(
+          './input/credential-termsofuse-id-ok.json'));
       });
       it2('The value of the evidence property MUST be one or more evidence ' +
         'schemes providing enough information for a verifier to determine ' +

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -180,10 +180,10 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       });
       it2('type property: "If more than one URL is provided, the URLs ' +
         'MUST be interpreted as an unordered set."', async function() {
-        //issue VC with multiple urls in type property
+        //issue Vc with multiple urls in type property
         await endpoints.issue(require(
           './input/credential-type-urls-order-1-ok.json'));
-        //issue another VC with same urls in a different order
+        //issue another Vc with same urls in a different order
         await endpoints.issue(require(
           './input/credential-type-urls-order-2-ok.json'));
       });
@@ -416,7 +416,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           presentationWithCredential,
           verifyPresentationOptions
         );
-        // FIXME support for derived VCs is not standard yet
+        // FIXME support for derived Vcs is not standard yet
         // and probably will be its own test suite
         //await endpoints.verifyVp(require(
         //  './input/presentation-derived-vc-ok.json'));

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2024 Digital Bazaar, Inc. All rights reserved.
  */
 import {
   createRequestBody,

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -1,0 +1,83 @@
+import {
+  createRequestBody,
+  createVerifyRequestBody
+} from './mock.data.js';
+import http from 'http';
+import {proveVP} from './data-generator.js';
+import receiveJson from './receive-json.js';
+
+export class TestEndpoints {
+  constructor({implementation, tag}) {
+    this.implementation = implementation;
+    this.tag = tag;
+    this.verifier = implementation.verifiers.find(
+      verifier => verifier.tags.has(tag));
+    this. issuer = implementation.issuers.find(
+      issuer => issuer.tags.has(tag));
+    this.vpVerifier = implementation.vpVerifiers.find(
+      vpVerifier => vpVerifier.tags.has(tag));
+  }
+  async issue(credential) {
+    const {issuer} = this;
+    const issueBody = createRequestBody({issuer, vc: credential});
+    return post(issuer, issueBody);
+  }
+  async proveVP({presentation, options = {}}) {
+    return proveVP({presentation, options});
+  }
+  async verify(vc) {
+    const verifyBody = createVerifyRequestBody({vc});
+    const result = await post(this.verifier, verifyBody);
+    if(result?.errors?.length) {
+      throw result.errors[0];
+    }
+    return result;
+  }
+  async verifyVp(vp, options = {checks: []}) {
+    const body = {
+      verifiablePresentation: vp,
+      options
+    };
+    const result = await post(this.vpVerifier, body);
+    if(result?.errors?.length) {
+      throw result.errors[0];
+    }
+    return result;
+  }
+}
+
+export async function post(endpoint, object) {
+  const url = endpoint.settings.endpoint;
+  if(url.startsWith('https:')) {
+    // Use vc-api-test-suite-implementations for HTTPS requests.
+    const {data, error} = await endpoint.post({json: object});
+    if(error) {
+      throw error;
+    }
+    return data;
+  }
+  const postData = Buffer.from(JSON.stringify(object));
+  const res = await new Promise((resolve, reject) => {
+    const req = http.request(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': postData.length,
+        Accept: 'application/json'
+      }
+    }, resolve);
+    req.on('error', reject);
+    req.end(postData);
+  });
+  const result = await receiveJson(res);
+  if(res.statusCode >= 400) {
+    if(result != null && result.errors) {
+      throw new Error(result.errors);
+    }
+    throw new Error(result);
+  }
+  if(res.statusCode >= 300) {
+    throw new Error('Redirect not supported');
+  }
+  return result;
+}

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -5,8 +5,8 @@ import {
   createRequestBody,
   createVerifyRequestBody
 } from './mock.data.js';
+import {createVp} from './data-generator.js';
 import http from 'http';
-import {proveVP} from './data-generator.js';
 import receiveJson from './receive-json.js';
 
 export class TestEndpoints {
@@ -25,8 +25,8 @@ export class TestEndpoints {
     const issueBody = createRequestBody({issuer, vc: credential});
     return post(issuer, issueBody);
   }
-  async proveVP({presentation, options = {}}) {
-    return proveVP({presentation, options});
+  async createVp({presentation, options = {}}) {
+    return createVp({presentation, options});
   }
   async verify(vc) {
     const verifyBody = createVerifyRequestBody({vc});

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -1,3 +1,6 @@
+/*!
+ * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ */
 import {
   createRequestBody,
   createVerifyRequestBody

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -15,7 +15,7 @@ export class TestEndpoints {
     this.tag = tag;
     this.verifier = implementation.verifiers.find(
       verifier => verifier.tags.has(tag));
-    this. issuer = implementation.issuers.find(
+    this.issuer = implementation.issuers.find(
       issuer => issuer.tags.has(tag));
     this.vpVerifier = implementation.vpVerifiers.find(
       vpVerifier => vpVerifier.tags.has(tag));

--- a/tests/data-generator.js
+++ b/tests/data-generator.js
@@ -9,6 +9,11 @@ import {
   cryptosuite as eddsa2022Cryptosuite
 } from '@digitalbazaar/eddsa-2022-cryptosuite';
 import {klona} from 'klona';
+import {randomFillSync} from 'node:crypto';
+
+// use base64 encoded 128 bit number as the challenge
+const buf = Buffer.alloc(16); // 128 bits
+export const challenge = 'u' + randomFillSync(buf).toString('base64url');
 
 const _documentLoader = url => {
   // adds support for the data integrity context

--- a/tests/data-generator.js
+++ b/tests/data-generator.js
@@ -56,14 +56,14 @@ async function getKeys() {
 }
 
 /**
- * An extremely basic Vp creator. This is not final
+ * An extremely basic VP creator. This is not final
  * and will probably change.
  *
  * @param {object} options - Options to use.
- * @param {object} options.presentation - An unsigned Vp.
- * @param {object} options.options - Options for the Vp.
+ * @param {object} options.presentation - An unsigned VP.
+ * @param {object} options.options - Options for the VP.
  *
- * @returns {Promise<object>} Resolves to a signed Vp.
+ * @returns {Promise<object>} Resolves to a signed VP.
  */
 export async function createVp({presentation, options = {}}) {
   const {signer, keyPair} = await getKeys({options});

--- a/tests/data-generator.js
+++ b/tests/data-generator.js
@@ -56,16 +56,16 @@ async function getKeys() {
 }
 
 /**
- * An extremely basic VP prover. This is not final
+ * An extremely basic Vp creator. This is not final
  * and will probably change.
  *
  * @param {object} options - Options to use.
- * @param {object} options.presentation - An unsigned VP.
- * @param {object} options.options - Options for the VP.
+ * @param {object} options.presentation - An unsigned Vp.
+ * @param {object} options.options - Options for the Vp.
  *
  * @returns {Promise<object>} Resolves to a signed Vp.
  */
-export async function proveVP({presentation, options = {}}) {
+export async function createVp({presentation, options = {}}) {
   const {signer, keyPair} = await getKeys({options});
   options.suite = new DataIntegrityProof({
     signer,

--- a/tests/input/credential-single-id-ok.json
+++ b/tests/input/credential-single-id-ok.json
@@ -9,6 +9,6 @@
   "id": "https://example.org/credentials/1",
   "issuer": "did:example:issuer",
   "credentialSubject": {
-    "description": "A single id test for VC 2.0"
+    "description": "A single id test for Vc 2.0"
   }
 }

--- a/tests/input/credential-single-id-ok.json
+++ b/tests/input/credential-single-id-ok.json
@@ -9,6 +9,6 @@
   "id": "https://example.org/credentials/1",
   "issuer": "did:example:issuer",
   "credentialSubject": {
-    "description": "A single id test for Vc 2.0"
+    "description": "A single id test for VC 2.0"
   }
 }


### PR DESCRIPTION
This is clean up: it removes tons of unneeded stuff from the actual test suite and instead creates an Endpoints class that really helps make the suite cleaner and makes it almost more inline with the rest of the suites. It also moves the challenge generation to `data-generator.js` further decluttering the test file.