### PR TITLE
Update respecConfig.json to use 'base' and not 'NOTE' as a spec status

### DIFF
--- a/respecConfig.json
+++ b/respecConfig.json
@@ -1,7 +1,7 @@
 {
   "shortName": "vc2.0-test-suite",
   "group": "vc",
-  "specStatus": "NOTE",
+  "specStatus": "base",
   "subtitle": "Verifiable Credentials Data Model v2.0 Interoperability Report",
   "github": "https://github.com/w3c/vc-data-model-2-test-suite",
   "edDraftURI": "https://w3c.github.io/vc-data-model-2-test-suite/",


### PR DESCRIPTION
This is to fulfil the VCDM CR Transition request comment https://github.com/w3c/transitions/issues/587#issuecomment-1900582168.

Cc: @plehegar @msporny