### PR TITLE
Properly license.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
+ */
+
 module.exports = {
   env: {
     node: true

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,7 @@ module.exports = {
     sourceType: 'module'
   },
   rules: {
-    'jsdoc/check-examples': 0
+    'jsdoc/check-examples': 0,
+    'max-len': ['error', {ignoreComments: true}]
   }
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,6 @@ module.exports = {
   },
   rules: {
     'jsdoc/check-examples': 0,
-    'max-len': ['error', {ignoreComments: true}]
+    'max-len': ['error', {ignorePattern: '\\* SPDX-License-Identifier: '}]
   }
 };

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,6 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Contact: Digital Bazaar, Inc. <support@digitalbazaar.com>
+
+Files: .gitignore .npmrc .github/* *.json
+Copyright: 2022-2024 W3C, Inc., 2022-2024 Digital Bazaar, Inc.
+LICENSE: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
+-->
+
 # w3c/vc-data-model-2.0-test-suite ChangeLog
 
 ## 1.1.0 - 2024-01-xx

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-All documents in this Repository are licensed by contributors
-under the 
-[W3C Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software).
-
+Distributed under both the
+[W3C test suite license](https://www.w3.org/copyright/test-suite-license-2023/)
+and the
+[W3C 3-clause BSD license](https://www.w3.org/copyright/3-clause-bsd-license-2008/).

--- a/LICENSES/LicenseRef-w3c-3-clause-bsd-license-2008.md
+++ b/LICENSES/LicenseRef-w3c-3-clause-bsd-license-2008.md
@@ -1,0 +1,24 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of works must retain the original copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the original copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of W3C nor the names of its contributors may be used to
+   endorse or promote products derived from this work without specific prior
+   written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/LicenseRef-w3c-test-suite-license-2023.md
+++ b/LICENSES/LicenseRef-w3c-test-suite-license-2023.md
@@ -1,0 +1,61 @@
+This document, test suites and other documents that link to this statement are
+provided by the copyright holders under the following license.
+
+## License
+
+By using and/or copying this document, or the W3C document from which this
+statement is linked, you (the licensee) agree that you have read, understood,
+and will comply with the following terms and conditions:
+
+Permission to copy, and distribute the contents of this document, or the W3C
+document from which this statement is linked, in any medium for any purpose and
+without fee or royalty is hereby granted, provided that you include the
+following on *ALL* copies of the document, or portions thereof, that you use:
+
+1.  A link or URL to the original W3C document.
+
+2.  The pre-existing copyright
+notice of the original author, or if it doesn't exist, a notice (hypertext is
+preferred, but a textual representation is permitted) of the form: "Copyright ©
+\[$year-of-document\] [World Wide Web Consortium](https://www.w3.org/). All
+Rights Reserved.
+[https://www.w3.org/copyright/test-suite-license-2023/](https://www.w3.org/copyright/test-suite-license-2023/)"
+
+3.  *If it exists*, the STATUS of the W3C document.
+
+When space permits, inclusion of the full text of this **NOTICE** should be
+provided. We request that authorship attribution be provided in any software,
+documents, or other items or products that you create pursuant to the
+implementation of the contents of this document, or any portion thereof.
+
+No right to create modifications or derivatives of W3C documents is granted
+pursuant to this license. However, if additional requirements (documented in
+the [Copyright FAQ](https://www.w3.org/copyright/intellectual-rights/)) are
+satisfied, the right to create modifications or derivatives is sometimes
+granted by W3C to individuals complying with those requirements.
+
+If a test suite distinguishes the test harness (or, framework for navigation)
+and the actual tests, permission is given to remove or alter the harness or
+navigation if the test suite in question allows to do so. The tests themselves
+shall NOT be changed in any way.
+
+The name and trademarks of W3C and other copyright holders may NOT be used in
+advertising or publicity pertaining to this document or other documents that
+link to this statement without specific, written prior permission. Title to
+copyright in this document will at all times remain with copyright holders.
+Permission is given to use the trademarked string W3C within claims of
+performance concerning W3C Specifications or features described therein, and
+there only, if the test suite so authorizes.
+
+## Disclaimers
+
+THIS WORK IS PROVIDED BY W3C, THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL W3C, THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
+-->
+
 # Verifiable Credentials v2.0 Test Suite
 
 This is the test suite for the W3C Verifiable Credentials Data Model (VCDM) v2.0

--- a/abstract.hbs
+++ b/abstract.hbs
@@ -1,3 +1,9 @@
+{{!--
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
+--}}
+
 <section id="abstract">
   <p>
 This is a interoperability report for implementers for the

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "email": "public-vc-wg@w3.org",
     "url": "https://www.w3.org/groups/wg/vc/"
   },
-  "license": "(BSD-3-Clause OR LicenseRef-scancode-w3c-test-suite)",
+  "license": "(LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023)",
   "engines": {
     "node": ">=18"
   },

--- a/tests/.eslintrc.cjs
+++ b/tests/.eslintrc.cjs
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
+ */
+
 module.exports = {
   env: {
     mocha: true

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2023 Digital Bazaar, Inc.
  */
 import {challenge, createTimeStamp} from './data-generator.js';
 import assert from 'node:assert/strict';

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc.
+/*
+ * Copyright 2022 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
  */
+
 import {challenge, createTimeStamp} from './data-generator.js';
 import assert from 'node:assert/strict';
 import chai from 'chai';

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2024 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2024 Digital Bazaar, Inc.
  */
 import {
   createRequestBody,

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright (c) 2024 Digital Bazaar, Inc.
+/*
+ * Copyright 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
  */
+
 import {
   createRequestBody,
   createVerifyRequestBody

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc.
+/*
+ * Copyright 2022 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
  */
+
 import chai from 'chai';
 
 const should = chai.should();

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2023 Digital Bazaar, Inc.
  */
 import chai from 'chai';
 

--- a/tests/data-generator.js
+++ b/tests/data-generator.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright (c) 2023 Digital Bazaar, Inc.
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
  */
+
 import * as ed25519Multikey from '@digitalbazaar/ed25519-multikey';
 import * as vc from '@digitalbazaar/vc';
 import {CONTEXT, CONTEXT_URL} from '@digitalbazaar/data-integrity-context';

--- a/tests/data-generator.js
+++ b/tests/data-generator.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2023 Digital Bazaar, Inc.
  */
 import * as ed25519Multikey from '@digitalbazaar/ed25519-multikey';
 import * as vc from '@digitalbazaar/vc';

--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2023 Digital Bazaar, Inc.
  */
 import {createRequire} from 'node:module';
 import {klona} from 'klona';

--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc.
+/*
+ * Copyright 2022 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
  */
+
 import {createRequire} from 'node:module';
 import {klona} from 'klona';
 const require = createRequire(import.meta.url);

--- a/tests/receive-json.js
+++ b/tests/receive-json.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc.
+/*
+ * Copyright 2022 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
  */
+
 export default async function receiveJson(stream) {
   const bufs = [];
   await new Promise((resolve, reject) => {

--- a/tests/receive-json.js
+++ b/tests/receive-json.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2023 Digital Bazaar, Inc.
  */
 export default async function receiveJson(stream) {
   const bufs = [];


### PR DESCRIPTION
Turns out the W3C does *not* use the `BSD-3-Clause` for test suites. There's a
[dedicated policy for test suites](https://www.w3.org/copyright/test-suites-licenses/).

This policy stipulates the use of a "forked" BSD-style license AND a unique
test suite license which are considered "mutually exclusive" and the selection
of which one applies is left to the _licensee_ (depending on the use case).

This PR makes that change as well as applying the custom license names to all
files (either directly or via the `.reuse/dep5` file) following the
[REUSE v3 specification](https://reuse.software/spec/). This can be tested
using the [reuse tool](https://github.com/fsfe/reuse-tool).
