### PR TITLE
Prevent `@vocab` catch-all for types as URL test.

### DIFF
--- a/tests/input/credential-type-unmapped-fail.json
+++ b/tests/input/credential-type-unmapped-fail.json
@@ -1,6 +1,7 @@
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2"
+    "https://www.w3.org/ns/credentials/v2",
+    {"@vocab": null}
   ],
   "type": [
     "VerifiableCredential",


### PR DESCRIPTION
The `@vocab` catch-all would mean that any compliant processor would
always only ever create URLs...even it invalid. Setting `@vocab` to
`null` should prevent that...which should cause a rejection.
