### PR TITLE
Rename implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-
 - Update statement for `credentialStatus.id` and `type` test.
 - Update statement for `credentialSchemas` test.
 - `credentialStatus.id` is now optional.
+- Update `vc-api-test-suite-implementations` to `vc-test-suite-implementations`.
 
 ## 1.0.0 - 2023-11-10
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chai": "^4.3.6",
     "klona": "^2.0.5",
     "mocha": "^10.0.0",
-    "vc-api-test-suite-implementations": "github:w3c/vc-test-suite-implementations"
+    "vc-test-suite-implementations": "github:w3c/vc-test-suite-implementations"
   },
   "devDependencies": {
     "eslint": "^8.19.0",

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -8,7 +8,7 @@ import {challenge, createTimeStamp} from './data-generator.js';
 import assert from 'node:assert/strict';
 import chai from 'chai';
 import {createRequire} from 'module';
-import {filterByTag} from 'vc-api-test-suite-implementations';
+import {filterByTag} from 'vc-test-suite-implementations';
 import {TestEndpoints} from './TestEndpoints.js';
 
 const should = chai.should();

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -55,7 +55,7 @@ export class TestEndpoints {
 export async function post(endpoint, object) {
   const url = endpoint.settings.endpoint;
   if(url.startsWith('https:')) {
-    // Use vc-api-test-suite-implementations for HTTPS requests.
+    // Use vc-test-suite-implementations for HTTPS requests.
     const {data, error} = await endpoint.post({json: object});
     if(error) {
       throw error;


### PR DESCRIPTION
updates the package.json to point at the correct `vc-test-suite-implementations` package.