### PR TITLE
Group tests into sections.

### DIFF
--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -307,25 +307,8 @@ describe('Credential Subject', function() {
   setupMatrix.call(this);
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
-    const createOptions = {challenge};
-    const verifyPresentationOptions = {
-      checks: ['proof'],
-      challenge
-    };
 
     describe(name, function() {
-      let issuedVc;
-      before(async function() {
-        try {
-          issuedVc = await endpoints.issue(require(
-            './input/credential-ok.json'));
-        } catch(e) {
-          console.error(
-            `Issuer: ${name} failed to issue "credential-ok.json".`,
-            e
-          );
-        }
-      });
       beforeEach(addPerTestMetadata);
 
       // @link https://w3c.github.io/vc-data-model/#credential-subject:~:text=A%20verifiable%20credential%20MUST%20have%20a%20credentialSubject%20property.
@@ -347,8 +330,19 @@ describe('Credential Subject', function() {
           endpoints.issue(require(
             './input/credential-subject-multiple-empty-fail.json')));
       });
+    });
+  }
+});
 
-      // 4.7 Issuer https://w3c.github.io/vc-data-model/#issuer
+// 4.7 Issuer https://w3c.github.io/vc-data-model/#issuer
+describe('Issuer', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+
+    describe(name, function() {
+      beforeEach(addPerTestMetadata);
+
       // @link https://w3c.github.io/vc-data-model/#issuer:~:text=A%20verifiable%20credential%20MUST%20have%20an%20issuer%20property.
       it('A verifiable credential MUST have an issuer property.',
         async function() {
@@ -404,8 +398,36 @@ describe('Credential Subject', function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-description-extra-prop-en-fail.json')));
       });
+    });
+  }
+});
 
-      // 4.8 Validity Period https://w3c.github.io/vc-data-model/#validity-period
+// 4.8 Validity Period https://w3c.github.io/vc-data-model/#validity-period
+describe('Validity Period', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+    const createOptions = {challenge};
+    const verifyPresentationOptions = {
+      checks: ['proof'],
+      challenge
+    };
+
+    describe(name, function() {
+      let issuedVc;
+      before(async function() {
+        try {
+          issuedVc = await endpoints.issue(require(
+            './input/credential-ok.json'));
+        } catch(e) {
+          console.error(
+            `Issuer: ${name} failed to issue "credential-ok.json".`,
+            e
+          );
+        }
+      });
+      beforeEach(addPerTestMetadata);
+
       // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20present%2C%20the%20value%20of%20the%20validFrom%20property%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%20value%20representing%20the%20date%20and%20time%20the%20credential%20becomes%20valid%2C%20which%20could%20be%20a%20date%20and%20time%20in%20the%20future%20or%20in%20the%20past.
       it('If present, the value of the validFrom property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -505,11 +505,6 @@ describe('Securing Mechanisms', function() {
   setupMatrix.call(this);
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
-    const createOptions = {challenge};
-    const verifyPresentationOptions = {
-      checks: ['proof'],
-      challenge
-    };
 
     describe(name, function() {
       let issuedVc;

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -19,7 +19,7 @@ const baseContextUrl = 'https://www.w3.org/ns/credentials/v2';
 const tag = 'vc2.0';
 const {match} = filterByTag({tags: [tag]});
 
-describe('Verifiable Credentials Data Model v2.0', function() {
+function setupMatrix() {
   // this will tell the report
   // to make an interop matrix with this suite
   this.matrix = true;
@@ -27,6 +27,48 @@ describe('Verifiable Credentials Data Model v2.0', function() {
   this.implemented = [...match.keys()];
   this.rowLabel = 'Test Name';
   this.columnLabel = 'Implementer';
+}
+
+function addPerTestMetadata() {
+  // append test meta data to the it/test this.
+  this.currentTest.cell = {
+    columnId: this.currentTest.parent.title,
+    rowId: this.currentTest.title
+  };
+}
+
+// 1.3 Conformance https://w3c.github.io/vc-data-model/#conformance
+describe('Basic Conformance', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+
+    describe(name, function() {
+      beforeEach(addPerTestMetadata);
+      // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=of%20this%20document-,MUST%20be%20enforced.,-A%20conforming%20document
+      it.skip('Conforming document (compliance): VCDM "MUST be enforced." ' +
+        '("all relevant normative statements in Sections 4. Basic Concepts, ' +
+        '5. Advanced Concepts, and 6. Syntaxes")', async function() {
+        // not specifically testable; handled by other section tests.
+      });
+      // @link https://w3c.github.io/vc-data-model/#types:~:text=MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20detected.
+      it('verifiers MUST produce errors when non-conforming documents ' +
+        'are detected.', async function() {
+        const doc = {
+          type: ['NonconformingDocument']
+        };
+        await assert.rejects(endpoints.verify(doc));
+        await assert.rejects(endpoints.verifyVp(doc));
+      });
+      // TODO re-review whether all broad MUST statements in this intro section
+      // are adequately covered by other tests, or if they need unique tests.
+    });
+  }
+});
+
+// 4.2 Contexts https://w3c.github.io/vc-data-model/#contexts
+describe('Contexts', function() {
+  setupMatrix.call(this);
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
     const createOptions = {challenge};
@@ -48,33 +90,8 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           );
         }
       });
-      beforeEach(function() {
-        // append test meta data to the it/test this.
-        this.currentTest.cell = {
-          columnId: this.currentTest.parent.title,
-          rowId: this.currentTest.title
-        };
-      });
-      // 1.3 Conformance https://w3c.github.io/vc-data-model/#conformance
-      // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=of%20this%20document-,MUST%20be%20enforced.,-A%20conforming%20document
-      it.skip('Conforming document (compliance): VCDM "MUST be enforced." ' +
-        '("all relevant normative statements in Sections 4. Basic Concepts, ' +
-        '5. Advanced Concepts, and 6. Syntaxes")', async function() {
-        // not specifically testable; handled by other section tests.
-      });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20detected.
-      it('verifiers MUST produce errors when non-conforming documents ' +
-        'are detected.', async function() {
-        const doc = {
-          type: ['NonconformingDocument']
-        };
-        await assert.rejects(endpoints.verify(doc));
-        await assert.rejects(endpoints.verifyVp(doc));
-      });
-      // TODO re-review whether all broad MUST statements in this intro section
-      // are adequately covered by other tests, or if they need unique tests.
+      beforeEach(addPerTestMetadata);
 
-      // 4.2 Contexts https://w3c.github.io/vc-data-model/#contexts
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20include%20a%20%40context%20property.
       it('Verifiable credentials MUST include a @context property.',
         async function() {

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -20,9 +20,6 @@ const tag = 'vc2.0';
 const {match} = filterByTag({tags: [tag]});
 
 describe('Verifiable Credentials Data Model v2.0', function() {
-  const summaries = new Set();
-  this.summary = summaries;
-  const reportData = [];
   // this will tell the report
   // to make an interop matrix with this suite
   this.matrix = true;
@@ -30,8 +27,6 @@ describe('Verifiable Credentials Data Model v2.0', function() {
   this.implemented = [...match.keys()];
   this.rowLabel = 'Test Name';
   this.columnLabel = 'Issuer';
-  // the reportData will be displayed under the test title
-  this.reportData = reportData;
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
     function reportRow(title, fn) {

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -146,25 +146,8 @@ describe('Identifiers', function() {
   setupMatrix.call(this);
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
-    const createOptions = {challenge};
-    const verifyPresentationOptions = {
-      checks: ['proof'],
-      challenge
-    };
 
     describe(name, function() {
-      let issuedVc;
-      before(async function() {
-        try {
-          issuedVc = await endpoints.issue(require(
-            './input/credential-ok.json'));
-        } catch(e) {
-          console.error(
-            `Issuer: ${name} failed to issue "credential-ok.json".`,
-            e
-          );
-        }
-      });
       beforeEach(addPerTestMetadata);
 
       // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20id%20property%20MUST%20express%20an%20identifier%20that%20others%20are%20expected%20to%20use%20when%20expressing%20statements%20about%20a%20specific%20thing%20identified%20by%20that%20identifier.
@@ -200,8 +183,36 @@ describe('Identifiers', function() {
           await assert.rejects(endpoints.issue(require(
             './input/credential-nonsingle-id-fail.json')));
         });
+    });
+  }
+});
 
-      // 4.4 Types https://w3c.github.io/vc-data-model/#types
+// 4.4 Types https://w3c.github.io/vc-data-model/#types
+describe('Types', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+    const createOptions = {challenge};
+    const verifyPresentationOptions = {
+      checks: ['proof'],
+      challenge
+    };
+
+    describe(name, function() {
+      let issuedVc;
+      before(async function() {
+        try {
+          issuedVc = await endpoints.issue(require(
+            './input/credential-ok.json'));
+        } catch(e) {
+          console.error(
+            `Issuer: ${name} failed to issue "credential-ok.json".`,
+            e
+          );
+        }
+      });
+      beforeEach(addPerTestMetadata);
+
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20have%20a%20type%20property.
       it('Verifiable credentials MUST have a type property.',
         async function() {

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -72,24 +72,8 @@ describe('Contexts', function() {
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
     const createOptions = {challenge};
-    const verifyPresentationOptions = {
-      checks: ['proof'],
-      challenge
-    };
 
     describe(name, function() {
-      let issuedVc;
-      before(async function() {
-        try {
-          issuedVc = await endpoints.issue(require(
-            './input/credential-ok.json'));
-        } catch(e) {
-          console.error(
-            `Issuer: ${name} failed to issue "credential-ok.json".`,
-            e
-          );
-        }
-      });
       beforeEach(addPerTestMetadata);
 
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20include%20a%20%40context%20property.
@@ -153,8 +137,36 @@ describe('Contexts', function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-context-combo4-fail.json')));
       });
+    });
+  }
+});
 
-      // 4.3 Identifiers https://w3c.github.io/vc-data-model/#identifiers
+// 4.3 Identifiers https://w3c.github.io/vc-data-model/#identifiers
+describe('Identifiers', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+    const createOptions = {challenge};
+    const verifyPresentationOptions = {
+      checks: ['proof'],
+      challenge
+    };
+
+    describe(name, function() {
+      let issuedVc;
+      before(async function() {
+        try {
+          issuedVc = await endpoints.issue(require(
+            './input/credential-ok.json'));
+        } catch(e) {
+          console.error(
+            `Issuer: ${name} failed to issue "credential-ok.json".`,
+            e
+          );
+        }
+      });
+      beforeEach(addPerTestMetadata);
+
       // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20id%20property%20MUST%20express%20an%20identifier%20that%20others%20are%20expected%20to%20use%20when%20expressing%20statements%20about%20a%20specific%20thing%20identified%20by%20that%20identifier.
       it('if present: "The id property MUST express an identifier ' +
         'that others are expected to use when expressing statements about a ' +

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -568,8 +568,24 @@ describe('Securing Mechanisms', function() {
         assert.rejects(endpoints.verify(require('./input/credential-ok.json')));
         // TODO: add enveloped proof test
       });
+    });
+  }
+});
 
-      // 4.10 Status https://w3c.github.io/vc-data-model/#status
+// 4.10 Status https://w3c.github.io/vc-data-model/#status
+describe('Status', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+    const createOptions = {challenge};
+    const verifyPresentationOptions = {
+      checks: ['proof'],
+      challenge
+    };
+
+    describe(name, function() {
+      beforeEach(addPerTestMetadata);
+
       // @link https://w3c.github.io/vc-data-model/#status:~:text=credential%20status%20object.-,If%20present%2C%20the%20normative%20guidance%20in%20Section%204.3%20Identifiers%20MUST%20be%20followed.,-type
       it('If present (credentialStatus.id), the normative guidance ' +
         'in Section 4.3 Identifiers MUST be followed.', async function() {

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -649,6 +649,18 @@ describe('Status', function() {
         await assert.rejects(endpoints.verifyVp(require(
           './input/presentation-derived-vc-missing-required-type-fail.json')));
       });
+    });
+  }
+});
+
+// 5. Advanced Concepts https://w3c.github.io/vc-data-model/#advanced-concepts
+describe('Advanced', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+
+    describe(name, function() {
+      beforeEach(addPerTestMetadata);
 
       // Advanced
       it('JSON-LD-based processors MUST produce an error when a ' +

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -16,8 +16,8 @@ const should = chai.should();
 const require = createRequire(import.meta.url);
 const baseContextUrl = 'https://www.w3.org/ns/credentials/v2';
 
-const vcApiTag = 'vc2.0';
-const {match} = filterByTag({tags: [vcApiTag]});
+const tag = 'vc2.0';
+const {match} = filterByTag({tags: [tag]});
 
 describe('Verifiable Credentials Data Model v2.0', function() {
   const summaries = new Set();
@@ -33,7 +33,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
   // the reportData will be displayed under the test title
   this.reportData = reportData;
   for(const [name, implementation] of match) {
-    const endpoints = new TestEndpoints({implementation, tag: vcApiTag});
+    const endpoints = new TestEndpoints({implementation, tag});
     function reportRow(title, fn) {
       it(title, async function() {
         // append test meta data to the it/test this.

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -407,25 +407,8 @@ describe('Validity Period', function() {
   setupMatrix.call(this);
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
-    const createOptions = {challenge};
-    const verifyPresentationOptions = {
-      checks: ['proof'],
-      challenge
-    };
 
     describe(name, function() {
-      let issuedVc;
-      before(async function() {
-        try {
-          issuedVc = await endpoints.issue(require(
-            './input/credential-ok.json'));
-        } catch(e) {
-          console.error(
-            `Issuer: ${name} failed to issue "credential-ok.json".`,
-            e
-          );
-        }
-      });
       beforeEach(addPerTestMetadata);
 
       // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20present%2C%20the%20value%20of%20the%20validFrom%20property%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%20value%20representing%20the%20date%20and%20time%20the%20credential%20becomes%20valid%2C%20which%20could%20be%20a%20date%20and%20time%20in%20the%20future%20or%20in%20the%20past.
@@ -513,8 +496,36 @@ describe('Validity Period', function() {
         // eslint-disable-next-line max-len, no-unused-vars
         const regexp = /-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))/;
       });
+    });
+  }
+});
 
-      // 4.9 Securing Mechanisms https://w3c.github.io/vc-data-model/#securing-mechanisms
+// 4.9 Securing Mechanisms https://w3c.github.io/vc-data-model/#securing-mechanisms
+describe('Securing Mechanisms', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+    const createOptions = {challenge};
+    const verifyPresentationOptions = {
+      checks: ['proof'],
+      challenge
+    };
+
+    describe(name, function() {
+      let issuedVc;
+      before(async function() {
+        try {
+          issuedVc = await endpoints.issue(require(
+            './input/credential-ok.json'));
+        } catch(e) {
+          console.error(
+            `Issuer: ${name} failed to issue "credential-ok.json".`,
+            e
+          );
+        }
+      });
+      beforeEach(addPerTestMetadata);
+
       // as of VC 2.0 this means a proof must be attached to an issued VC
       // at least one proof must be on an issued VC
       // @link https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20document%20MUST%20be%20secured%20by%20at%20least%20one%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -29,17 +29,6 @@ describe('Verifiable Credentials Data Model v2.0', function() {
   this.columnLabel = 'Implementer';
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
-    function reportRow(title, fn) {
-      it(title, async function() {
-        // append test meta data to the it/test this.
-        this.test.cell = {
-          columnId: name,
-          rowId: this.test.title
-        };
-        // apply the test's this to the function that runs the test
-        await fn.apply(this, arguments);
-      });
-    }
     const createOptions = {challenge};
     const verifyPresentationOptions = {
       checks: ['proof'],
@@ -59,6 +48,13 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           );
         }
       });
+      beforeEach(function() {
+        // append test meta data to the it/test this.
+        this.currentTest.cell = {
+          columnId: this.currentTest.parent.title,
+          rowId: this.currentTest.title
+        };
+      });
       // 1.3 Conformance https://w3c.github.io/vc-data-model/#conformance
       // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=of%20this%20document-,MUST%20be%20enforced.,-A%20conforming%20document
       it.skip('Conforming document (compliance): VCDM "MUST be enforced." ' +
@@ -67,7 +63,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // not specifically testable; handled by other section tests.
       });
       // @link https://w3c.github.io/vc-data-model/#types:~:text=MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20detected.
-      reportRow('verifiers MUST produce errors when non-conforming documents ' +
+      it('verifiers MUST produce errors when non-conforming documents ' +
         'are detected.', async function() {
         const doc = {
           type: ['NonconformingDocument']
@@ -80,7 +76,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
 
       // 4.2 Contexts https://w3c.github.io/vc-data-model/#contexts
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20include%20a%20%40context%20property.
-      reportRow('Verifiable credentials MUST include a @context property.',
+      it('Verifiable credentials MUST include a @context property.',
         async function() {
           // positive @context test
           const vc = await endpoints.issue(require(
@@ -91,7 +87,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
             require('./input/credential-no-context-fail.json')));
         });
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20include%20a%20%40context%20property.
-      reportRow('Verifiable presentations MUST include a @context property.',
+      it('Verifiable presentations MUST include a @context property.',
         async function() {
           const vp = await endpoints.createVp({
             presentation: require('./input/presentation-ok.json'),
@@ -102,7 +98,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
             require('./input/presentation-no-context-fail.json')));
         });
       // @link https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20%40context%20property%20MUST%20be%20an%20ordered%20set%20where%20the%20first%20item%20is%20a%20URL%20with%20the%20value%20https%3A//www.w3.org/ns/credentials/v2.
-      reportRow('Verifiable credentials: The value of the @context property ' +
+      it('Verifiable credentials: The value of the @context property ' +
         'MUST be an ordered set where the first item is a URL with the value ' +
         'https://www.w3.org/ns/credentials/v2.', async function() {
         //positive issue test
@@ -114,7 +110,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           require('./input/credential-missing-base-context-fail.json')));
       });
       // @link https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20%40context%20property%20MUST%20be%20an%20ordered%20set%20where%20the%20first%20item%20is%20a%20URL%20with%20the%20value%20https%3A//www.w3.org/ns/credentials/v2.
-      reportRow('Verifiable presentations: The value of the @context ' +
+      it('Verifiable presentations: The value of the @context ' +
         'property MUST be an ordered set where the first item is a URL with ' +
         'the value https://www.w3.org/ns/credentials/v2.', async function() {
         const vp = await endpoints.createVp({
@@ -128,7 +124,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       });
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Subsequent%20items%20in%20the%20array%20MUST%20be%20composed%20of%20any%20combination%20of%20URLs%20and/or%20objects%20where%20each%20is%20processable%20as%20a%20JSON%2DLD%20Context.
       // TODO: Missing VP variation
-      reportRow('Verifiable credential @context: "Subsequent items in the ' +
+      it('Verifiable credential @context: "Subsequent items in the ' +
         'array MUST be composed of any combination of URLs and/or objects ' +
         'where each is processable as a JSON-LD Context."', async function() {
         await endpoints.issue(require(
@@ -143,7 +139,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
 
       // 4.3 Identifiers https://w3c.github.io/vc-data-model/#identifiers
       // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20id%20property%20MUST%20express%20an%20identifier%20that%20others%20are%20expected%20to%20use%20when%20expressing%20statements%20about%20a%20specific%20thing%20identified%20by%20that%20identifier.
-      reportRow('if present: "The id property MUST express an identifier ' +
+      it('if present: "The id property MUST express an identifier ' +
         'that others are expected to use when expressing statements about a ' +
         'specific thing identified by that identifier."', async function() {
         await endpoints.issue(require('./input/credential-id-other-ok.json'));
@@ -152,7 +148,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
             './input/credential-id-nonidentifier-fail.json')));
       });
       // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20id%20property%20MUST%20NOT%20have%20more%20than%20one%20value.
-      reportRow('if present: "The id property MUST NOT have more than one ' +
+      it('if present: "The id property MUST NOT have more than one ' +
         'value."', async function() {
         await endpoints.issue(require(
           './input/credential-single-id-ok.json'));
@@ -164,13 +160,13 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-subject-multi-id-fail.json')));
       });
       // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20value%20of%20the%20id%20property%20MUST%20be%20a%20URL%20which%20MAY%20be%20dereferenced.
-      reportRow('if present: "The value of the id property MUST be a URL ' +
+      it('if present: "The value of the id property MUST be a URL ' +
         'which MAY be dereferenced."', async function() {
         await assert.rejects(
           endpoints.issue(require('./input/credential-not-url-id-fail.json')));
       });
       // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20value%20of%20the%20id%20property%20MUST%20be%20a%20single%20URL.
-      reportRow('The value of the id property MUST be a single URL.',
+      it('The value of the id property MUST be a single URL.',
         async function() {
           await assert.rejects(endpoints.issue(require(
             './input/credential-nonsingle-id-fail.json')));
@@ -178,19 +174,19 @@ describe('Verifiable Credentials Data Model v2.0', function() {
 
       // 4.4 Types https://w3c.github.io/vc-data-model/#types
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20have%20a%20type%20property.
-      reportRow('Verifiable credentials MUST have a type property.',
+      it('Verifiable credentials MUST have a type property.',
         async function() {
           await assert.rejects(
             endpoints.issue(require('./input/credential-no-type-fail.json')));
         });
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20have%20a%20type%20property.
-      reportRow('Verifiable presentations MUST have a type property.',
+      it('Verifiable presentations MUST have a type property.',
         async function() {
           await assert.rejects(endpoints.verifyVp(require(
             './input/presentation-no-type-fail.json')));
         });
       // @link https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20type%20property%20MUST%20be%2C%20or%20map%20to%20(through%20interpretation%20of%20the%20%40context%20property)%2C%20one%20or%20more%20URLs.
-      reportRow('The value of the type property MUST be, or map to (through ' +
+      it('The value of the type property MUST be, or map to (through ' +
         'interpretation of the @context property), one or more URLs.',
       async function() {
         // type is URL: OK
@@ -206,7 +202,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-type-unmapped-fail.json')));
       });
       // @link https://w3c.github.io/vc-data-model/#types:~:text=If%20more%20than%20one%20URL%20is%20provided%2C%20the%20URLs%20MUST%20be%20interpreted%20as%20an%20unordered%20set.
-      reportRow('type property: "If more than one URL is provided, the URLs ' +
+      it('type property: "If more than one URL is provided, the URLs ' +
         'MUST be interpreted as an unordered set."', async function() {
         //issue VC with multiple urls in type property
         await endpoints.issue(require(
@@ -223,7 +219,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       // credentialStatus MUST have a type specified.
       // termsOfUse MUST have a type specified.
       // evidence MUST have a type specified.
-      reportRow('list: "objects that MUST have a type specified."',
+      it('list: "objects that MUST have a type specified."',
         async function() {
         // (Verifiable) credential requires type VerifiableCredential
         // (Verifiable) presentation requires type VerifiablePresentation
@@ -276,13 +272,13 @@ describe('Verifiable Credentials Data Model v2.0', function() {
 
       // 4.6 Credential Subject https://w3c.github.io/vc-data-model/#credential-subject
       // @link https://w3c.github.io/vc-data-model/#credential-subject:~:text=A%20verifiable%20credential%20MUST%20have%20a%20credentialSubject%20property.
-      reportRow('A verifiable credential MUST have a credentialSubject ' +
+      it('A verifiable credential MUST have a credentialSubject ' +
         'property.', async function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-no-subject-fail.json')));
       });
       // @link https://w3c.github.io/vc-data-model/#credential-subject:~:text=The%20value%20of%20the%20credentialSubject%20property%20is%20defined%20as%20a%20set%20of%20objects%20where%20each%20object%20MUST%20be%20the%20subject%20of%20one%20or%20more%20claims%2C%20which%20MUST%20be%20serialized%20inside%20the%20credentialSubject%20property.
-      reportRow('The value of the credentialSubject property is defined as a ' +
+      it('The value of the credentialSubject property is defined as a ' +
       'set of objects where each object MUST be the subject of one or more ' +
         'claims, which MUST be serialized inside the credentialSubject ' +
         'property.', async function() {
@@ -297,13 +293,13 @@ describe('Verifiable Credentials Data Model v2.0', function() {
 
       // 4.7 Issuer https://w3c.github.io/vc-data-model/#issuer
       // @link https://w3c.github.io/vc-data-model/#issuer:~:text=A%20verifiable%20credential%20MUST%20have%20an%20issuer%20property.
-      reportRow('A verifiable credential MUST have an issuer property.',
+      it('A verifiable credential MUST have an issuer property.',
         async function() {
           await assert.rejects(
             endpoints.issue(require('./input/credential-no-issuer-fail.json')));
         });
       // @link https://w3c.github.io/vc-data-model/#issuer:~:text=The%20value%20of%20the%20issuer%20property%20MUST%20be%20either%20a%20URL%2C%20or%20an%20object%20containing%20an%20id%20property%20whose%20value%20is%20a%20URL
-      reportRow('The value of the issuer property MUST be either a URL, or ' +
+      it('The value of the issuer property MUST be either a URL, or ' +
       'an object containing an id property whose value is a URL.',
       async function() {
         await endpoints.issue(require(
@@ -317,7 +313,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-issuer-object-id-not-url-fail.json')));
       });
       // TODO: remove. no longer present.
-      reportRow('If present, the value of the "issuer.name" property MUST be ' +
+      it('If present, the value of the "issuer.name" property MUST be ' +
       'a string or a language value object as described in 10.1 Language and ' +
         'Base Direction.', async function() {
         await endpoints.issue(require(
@@ -334,7 +330,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-issuer-name-extra-prop-en-fail.json')));
       });
       // TODO: remove. no longer present.
-      reportRow('If present, the value of the "issuer.description" property ' +
+      it('If present, the value of the "issuer.description" property ' +
         'MUST be a string or a language value object as described in 10.1 ' +
         'Language and Base Direction.', async function() {
         await endpoints.issue(require(
@@ -354,7 +350,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
 
       // 4.8 Validity Period https://w3c.github.io/vc-data-model/#validity-period
       // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20present%2C%20the%20value%20of%20the%20validFrom%20property%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%20value%20representing%20the%20date%20and%20time%20the%20credential%20becomes%20valid%2C%20which%20could%20be%20a%20date%20and%20time%20in%20the%20future%20or%20in%20the%20past.
-      reportRow('If present, the value of the validFrom property MUST be an ' +
+      it('If present, the value of the validFrom property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +
         'and time the credential becomes valid, which could be a date and ' +
         'time in the future or in the past.', async function() {
@@ -367,7 +363,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // TODO: add validFrom in the future test vector.
       });
       // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20present%2C%20the%20value%20of%20the%20validUntil%20property%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%20value%20representing%20the%20date%20and%20time%20the%20credential%20ceases%20to%20be%20valid%2C%20which%20could%20be%20a%20date%20and%20time%20in%20the%20past%20or%20in%20the%20future
-      reportRow('If present, the value of the validUntil property MUST be an ' +
+      it('If present, the value of the validUntil property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +
         'and time the credential ceases to be valid, which could be a date ' +
         'and time in the past or in the future.', async function() {
@@ -380,7 +376,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-validuntil-invalid-fail.json')));
       });
       // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validUntil%20value%20also%20exists%2C%20the%20validFrom%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20earlier%20than%20the%20datetime%20expressed%20by%20the%20validUntil%20value.
-      reportRow('If a validUntil value also exists, the validFrom value MUST ' +
+      it('If a validUntil value also exists, the validFrom value MUST ' +
         'express a datetime that is temporally the same or earlier than the ' +
         'datetime expressed by the validUntil value.', async function() {
         const positiveTest = require(
@@ -405,7 +401,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         assert.rejects(endpoints.verify(result));
       });
       // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validFrom%20value%20also%20exists%2C%20the%20validUntil%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20later%20than%20the%20datetime%20expressed%20by%20the%20validFrom%20value.
-      reportRow('If a validFrom value also exists, the validUntil value MUST ' +
+      it('If a validFrom value also exists, the validUntil value MUST ' +
         'express a datetime that is temporally the same or later than the ' +
         'datetime expressed by the validFrom value.', async function() {
         const positiveTest = require(
@@ -443,7 +439,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       // as of VC 2.0 this means a proof must be attached to an issued VC
       // at least one proof must be on an issued VC
       // @link https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20document%20MUST%20be%20secured%20by%20at%20least%20one%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.
-      reportRow('A conforming document MUST be secured by at least one ' +
+      it('A conforming document MUST be secured by at least one ' +
         'securing mechanism as described in Section 4.9 Securing Mechanisms.',
       async function() {
         // embedded proof test
@@ -461,7 +457,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // TODO: add enveloped proof test
       });
       // @link https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20issuer%20implementation%20produces%20conforming%20documents%2C%20MUST%20include%20all%20required%20properties%20in%20the%20conforming%20documents%20that%20it%20produces%2C%20and%20MUST%20secure%20the%20conforming%20documents%20it%20produces%20using%20a%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.
-      reportRow('A conforming issuer implementation produces conforming ' +
+      it('A conforming issuer implementation produces conforming ' +
         'documents, MUST include all required properties in the conforming ' +
         'documents that it produces, and MUST secure the conforming ' +
         'documents it produces using a securing mechanism as described in ' +
@@ -471,7 +467,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // TODO: add enveloped proof test
       });
       // @link https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20verifier,documents%20are%20detected.
-      reportRow('A conforming verifier implementation consumes conforming ' +
+      it('A conforming verifier implementation consumes conforming ' +
       'documents, MUST perform verification on a conforming document as ' +
       'described in Section 4.9 Securing Mechanisms, MUST check that each ' +
       'required property satisfies the normative requirements for that ' +
@@ -485,7 +481,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
 
       // 4.10 Status https://w3c.github.io/vc-data-model/#status
       // @link https://w3c.github.io/vc-data-model/#status:~:text=credential%20status%20object.-,If%20present%2C%20the%20normative%20guidance%20in%20Section%204.3%20Identifiers%20MUST%20be%20followed.,-type
-      reportRow('If present (credentialStatus.id), the normative guidance ' +
+      it('If present (credentialStatus.id), the normative guidance ' +
         'in Section 4.3 Identifiers MUST be followed.', async function() {
         // id is optional
         await endpoints.issue(require(
@@ -496,7 +492,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
           './input/credential-status-nonurl-id-fail.json')));
       });
       // @link https://w3c.github.io/vc-data-model/#status:~:text=The%20type%20property%20is%20REQUIRED.%20It%20is%20used%20to%20express%20the%20type%20of%20status%20information%20expressed%20by%20the%20object.%20The%20related%20normative%20guidance%20in%20Section%204.4%20Types%20MUST%20be%20followed.
-      reportRow('(If a credentialStatus property is present), The type ' +
+      it('(If a credentialStatus property is present), The type ' +
         'property is REQUIRED. It is used to express the type of status ' +
         'information expressed by the object. The related normative ' +
         'guidance in Section 4.4 Types MUST be followed.', async function() {
@@ -513,7 +509,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         // not testable with automation
       });
 
-      reportRow('In Verifiable Presentations, the verifiableCredential ' +
+      it('In Verifiable Presentations, the verifiableCredential ' +
         'property MAY be present. The value MUST be an array of one or more ' +
         'verifiable credential graphs in a cryptographically verifiable ' +
         'format.', async function() {
@@ -549,7 +545,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
       });
 
       // Advanced
-      reportRow('JSON-LD-based processors MUST produce an error when a ' +
+      it('JSON-LD-based processors MUST produce an error when a ' +
         'JSON-LD context redefines any term in the active context.',
       async function() {
         // This depends on "@protected" (which is used for the base context).
@@ -558,21 +554,21 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-redef-type2-fail.json')));
       });
-      reportRow('The value of the credentialSchema property MUST be one or ' +
+      it('The value of the credentialSchema property MUST be one or ' +
         'more data schemas that provide verifiers with enough information to ' +
         'determine whether the provided data conforms to the provided ' +
         'schema(s).', async function() {
         await endpoints.issue(require('./input/credential-schema-ok.json'));
         await endpoints.issue(require('./input/credential-schemas-ok.json'));
       });
-      reportRow('Each credentialSchema MUST specify its type (for example, ' +
+      it('Each credentialSchema MUST specify its type (for example, ' +
         'JsonSchemaValidator2018), and an id property.', async function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-schema-no-type-fail.json')));
         await assert.rejects(endpoints.issue(require(
           './input/credential-schema-no-id-fail.json')));
       });
-      reportRow('credentialSchema id MUST be a URL identifying the schema ' +
+      it('credentialSchema id MUST be a URL identifying the schema ' +
         'file.', async function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-schema-non-url-id-fail.json')));
@@ -594,20 +590,20 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-refresh-non-url-id-fail.json')));
       });
-      reportRow('The value of the termsOfUse property MUST specify one or ' +
+      it('The value of the termsOfUse property MUST specify one or ' +
         'more terms of use policies under which the creator issued the ' +
         'credential or presentation.', async function() {
         await endpoints.issue(require(
           './input/credential-termsofuses-ok.json'));
       });
-      reportRow('Each termsOfUse value MUST specify its type, for example, ' +
+      it('Each termsOfUse value MUST specify its type, for example, ' +
         'IssuerPolicy, and MAY specify its instance id.', async function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-termsofuse-no-type-fail.json')));
         await endpoints.issue(require(
           './input/credential-termsofuse-id-ok.json'));
       });
-      reportRow('The value of the evidence property MUST be one or more ' +
+      it('The value of the evidence property MUST be one or more ' +
         'evidence schemes providing enough information for a verifier to ' +
         'determine whether the evidence gathered by the issuer meets its ' +
         'confidence requirements for relying on the credential.',

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -26,7 +26,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
   this.report = true;
   this.implemented = [...match.keys()];
   this.rowLabel = 'Test Name';
-  this.columnLabel = 'Issuer';
+  this.columnLabel = 'Implementer';
   for(const [name, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});
     function reportRow(title, fn) {

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -199,18 +199,6 @@ describe('Types', function() {
     };
 
     describe(name, function() {
-      let issuedVc;
-      before(async function() {
-        try {
-          issuedVc = await endpoints.issue(require(
-            './input/credential-ok.json'));
-        } catch(e) {
-          console.error(
-            `Issuer: ${name} failed to issue "credential-ok.json".`,
-            e
-          );
-        }
-      });
       beforeEach(addPerTestMetadata);
 
       // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20have%20a%20type%20property.
@@ -306,11 +294,40 @@ describe('Types', function() {
       async function() {
         // skipping because SHOULD (not MUST)
       });
+    });
+  }
+});
 
-      // 4.5 Names and Descriptions https://w3c.github.io/vc-data-model/#names-and-descriptions
-      // skipping tests for name and descrpition which are OPTIONAL properties
+// 4.5 Names and Descriptions https://w3c.github.io/vc-data-model/#names-and-descriptions
+// skipping tests for name and descrpition which are OPTIONAL properties
+// TODO: report that this section of the spec is being skipped and why
 
-      // 4.6 Credential Subject https://w3c.github.io/vc-data-model/#credential-subject
+// 4.6 Credential Subject https://w3c.github.io/vc-data-model/#credential-subject
+describe('Credential Subject', function() {
+  setupMatrix.call(this);
+  for(const [name, implementation] of match) {
+    const endpoints = new TestEndpoints({implementation, tag});
+    const createOptions = {challenge};
+    const verifyPresentationOptions = {
+      checks: ['proof'],
+      challenge
+    };
+
+    describe(name, function() {
+      let issuedVc;
+      before(async function() {
+        try {
+          issuedVc = await endpoints.issue(require(
+            './input/credential-ok.json'));
+        } catch(e) {
+          console.error(
+            `Issuer: ${name} failed to issue "credential-ok.json".`,
+            e
+          );
+        }
+      });
+      beforeEach(addPerTestMetadata);
+
       // @link https://w3c.github.io/vc-data-model/#credential-subject:~:text=A%20verifiable%20credential%20MUST%20have%20a%20credentialSubject%20property.
       it('A verifiable credential MUST have a credentialSubject ' +
         'property.', async function() {


### PR DESCRIPTION
It was getting very hard to understand the growing list of MUSTs relative to
the specification. The tests are now grouped into similarly named sections
with links in the code (at least) to those sections.

I plan to do more (likely in the upstream reporter) to make it possible to
link to the sections of the spec and provide basic descriptions of what the
tests are about.

Note: this one stacks on top of #73 which is still being polished.
