### PR TITLE
Move link comments to be link data.

### DIFF
--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -45,15 +45,15 @@ describe('Basic Conformance', function() {
 
     describe(name, function() {
       beforeEach(addPerTestMetadata);
-      // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=of%20this%20document-,MUST%20be%20enforced.,-A%20conforming%20document
       it.skip('Conforming document (compliance): VCDM "MUST be enforced." ' +
         '("all relevant normative statements in Sections 4. Basic Concepts, ' +
         '5. Advanced Concepts, and 6. Syntaxes")', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#identifiers:~:text=of%20this%20document-,MUST%20be%20enforced.,-A%20conforming%20document`;
         // not specifically testable; handled by other section tests.
       });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20detected.
       it('verifiers MUST produce errors when non-conforming documents ' +
         'are detected.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20detected.`;
         const doc = {
           type: ['NonconformingDocument']
         };
@@ -76,9 +76,9 @@ describe('Contexts', function() {
     describe(name, function() {
       beforeEach(addPerTestMetadata);
 
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20include%20a%20%40context%20property.
       it('Verifiable credentials MUST include a @context property.',
         async function() {
+          this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20include%20a%20%40context%20property.`;
           // positive @context test
           const vc = await endpoints.issue(require(
             './input/credential-ok.json'));
@@ -87,9 +87,9 @@ describe('Contexts', function() {
           await assert.rejects(endpoints.issue(
             require('./input/credential-no-context-fail.json')));
         });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20include%20a%20%40context%20property.
       it('Verifiable presentations MUST include a @context property.',
         async function() {
+          this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20include%20a%20%40context%20property.`;
           const vp = await endpoints.createVp({
             presentation: require('./input/presentation-ok.json'),
             options: createOptions
@@ -98,10 +98,10 @@ describe('Contexts', function() {
           await assert.rejects(endpoints.verifyVp(
             require('./input/presentation-no-context-fail.json')));
         });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20%40context%20property%20MUST%20be%20an%20ordered%20set%20where%20the%20first%20item%20is%20a%20URL%20with%20the%20value%20https%3A//www.w3.org/ns/credentials/v2.
       it('Verifiable credentials: The value of the @context property ' +
         'MUST be an ordered set where the first item is a URL with the value ' +
         'https://www.w3.org/ns/credentials/v2.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20%40context%20property%20MUST%20be%20an%20ordered%20set%20where%20the%20first%20item%20is%20a%20URL%20with%20the%20value%20https%3A//www.w3.org/ns/credentials/v2.`;
         //positive issue test
         const vc = await endpoints.issue(require('./input/credential-ok.json'));
         assert(Array.isArray(vc['@context']));
@@ -110,10 +110,10 @@ describe('Contexts', function() {
         await assert.rejects(endpoints.issue(
           require('./input/credential-missing-base-context-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20%40context%20property%20MUST%20be%20an%20ordered%20set%20where%20the%20first%20item%20is%20a%20URL%20with%20the%20value%20https%3A//www.w3.org/ns/credentials/v2.
       it('Verifiable presentations: The value of the @context ' +
         'property MUST be an ordered set where the first item is a URL with ' +
         'the value https://www.w3.org/ns/credentials/v2.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20%40context%20property%20MUST%20be%20an%20ordered%20set%20where%20the%20first%20item%20is%20a%20URL%20with%20the%20value%20https%3A//www.w3.org/ns/credentials/v2.`;
         const vp = await endpoints.createVp({
           presentation: require('./input/presentation-ok.json'),
           options: createOptions
@@ -123,11 +123,11 @@ describe('Contexts', function() {
         await assert.rejects(endpoints.verifyVp(
           require('./input/presentation-missing-base-context-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=Subsequent%20items%20in%20the%20array%20MUST%20be%20composed%20of%20any%20combination%20of%20URLs%20and/or%20objects%20where%20each%20is%20processable%20as%20a%20JSON%2DLD%20Context.
       // TODO: Missing VP variation
       it('Verifiable credential @context: "Subsequent items in the ' +
         'array MUST be composed of any combination of URLs and/or objects ' +
         'where each is processable as a JSON-LD Context."', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=Subsequent%20items%20in%20the%20array%20MUST%20be%20composed%20of%20any%20combination%20of%20URLs%20and/or%20objects%20where%20each%20is%20processable%20as%20a%20JSON%2DLD%20Context.`;
         await endpoints.issue(require(
           './input/credential-context-combo1-ok.json'));
         await endpoints.issue(require(
@@ -150,18 +150,18 @@ describe('Identifiers', function() {
     describe(name, function() {
       beforeEach(addPerTestMetadata);
 
-      // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20id%20property%20MUST%20express%20an%20identifier%20that%20others%20are%20expected%20to%20use%20when%20expressing%20statements%20about%20a%20specific%20thing%20identified%20by%20that%20identifier.
       it('if present: "The id property MUST express an identifier ' +
         'that others are expected to use when expressing statements about a ' +
         'specific thing identified by that identifier."', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20id%20property%20MUST%20express%20an%20identifier%20that%20others%20are%20expected%20to%20use%20when%20expressing%20statements%20about%20a%20specific%20thing%20identified%20by%20that%20identifier.`;
         await endpoints.issue(require('./input/credential-id-other-ok.json'));
         await assert.rejects(
           endpoints.issue(require(
             './input/credential-id-nonidentifier-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20id%20property%20MUST%20NOT%20have%20more%20than%20one%20value.
       it('if present: "The id property MUST NOT have more than one ' +
         'value."', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20id%20property%20MUST%20NOT%20have%20more%20than%20one%20value.`;
         await endpoints.issue(require(
           './input/credential-single-id-ok.json'));
         await endpoints.issue(require(
@@ -171,15 +171,15 @@ describe('Identifiers', function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-subject-multi-id-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20value%20of%20the%20id%20property%20MUST%20be%20a%20URL%20which%20MAY%20be%20dereferenced.
       it('if present: "The value of the id property MUST be a URL ' +
         'which MAY be dereferenced."', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20value%20of%20the%20id%20property%20MUST%20be%20a%20URL%20which%20MAY%20be%20dereferenced.`;
         await assert.rejects(
           endpoints.issue(require('./input/credential-not-url-id-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20value%20of%20the%20id%20property%20MUST%20be%20a%20single%20URL.
       it('The value of the id property MUST be a single URL.',
         async function() {
+          this.test.link = `https://w3c.github.io/vc-data-model/#identifiers:~:text=The%20value%20of%20the%20id%20property%20MUST%20be%20a%20single%20URL.`;
           await assert.rejects(endpoints.issue(require(
             './input/credential-nonsingle-id-fail.json')));
         });
@@ -201,22 +201,22 @@ describe('Types', function() {
     describe(name, function() {
       beforeEach(addPerTestMetadata);
 
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20have%20a%20type%20property.
       it('Verifiable credentials MUST have a type property.',
         async function() {
+          this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20have%20a%20type%20property.`;
           await assert.rejects(
             endpoints.issue(require('./input/credential-no-type-fail.json')));
         });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20have%20a%20type%20property.
       it('Verifiable presentations MUST have a type property.',
         async function() {
+          this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20have%20a%20type%20property.`;
           await assert.rejects(endpoints.verifyVp(require(
             './input/presentation-no-type-fail.json')));
         });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20type%20property%20MUST%20be%2C%20or%20map%20to%20(through%20interpretation%20of%20the%20%40context%20property)%2C%20one%20or%20more%20URLs.
       it('The value of the type property MUST be, or map to (through ' +
         'interpretation of the @context property), one or more URLs.',
       async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=The%20value%20of%20the%20type%20property%20MUST%20be%2C%20or%20map%20to%20(through%20interpretation%20of%20the%20%40context%20property)%2C%20one%20or%20more%20URLs.`;
         // type is URL: OK
         await endpoints.issue(require('./input/credential-type-url-ok.json'));
         // type mapping to URL: OK
@@ -229,9 +229,9 @@ describe('Types', function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-type-unmapped-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=If%20more%20than%20one%20URL%20is%20provided%2C%20the%20URLs%20MUST%20be%20interpreted%20as%20an%20unordered%20set.
       it('type property: "If more than one URL is provided, the URLs ' +
         'MUST be interpreted as an unordered set."', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=If%20more%20than%20one%20URL%20is%20provided%2C%20the%20URLs%20MUST%20be%20interpreted%20as%20an%20unordered%20set.`;
         //issue VC with multiple urls in type property
         await endpoints.issue(require(
           './input/credential-type-urls-order-1-ok.json'));
@@ -239,7 +239,6 @@ describe('Types', function() {
         await endpoints.issue(require(
           './input/credential-type-urls-order-2-ok.json'));
       });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=the%20following%20table%20lists%20the%20objects%20that%20MUST%20have%20a%20type%20specified.
       // FIXME this needs to be expanded into at least 6 different tests
       // Verifiable Credential MUST have a type specified
       // Verifiable Presentation MUST have a type specified
@@ -249,10 +248,11 @@ describe('Types', function() {
       // evidence MUST have a type specified.
       it('list: "objects that MUST have a type specified."',
         async function() {
-        // (Verifiable) credential requires type VerifiableCredential
-        // (Verifiable) presentation requires type VerifiablePresentation
-        // Additional (more specific) types for these are optional.
-        // Missing type property is tested separately.
+          this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=the%20following%20table%20lists%20the%20objects%20that%20MUST%20have%20a%20type%20specified.`;
+          // (Verifiable) credential requires type VerifiableCredential
+          // (Verifiable) presentation requires type VerifiablePresentation
+          // Additional (more specific) types for these are optional.
+          // Missing type property is tested separately.
           await endpoints.issue(require(
             './input/credential-optional-type-ok.json'));
           await assert.rejects(endpoints.issue(require(
@@ -286,12 +286,12 @@ describe('Types', function() {
           await assert.rejects(endpoints.issue(require(
             './input/credential-evidence-missing-type-fail.json')));
         });
-      // @link https://w3c.github.io/vc-data-model/#types:~:text=All%20credentials%2C%20presentations%2C%20and%20encapsulated%20objects%20SHOULD%20specify%2C%20or%20be%20associated%20with%2C%20additional%20more%20narrow%20types%20(like%20ExampleDegreeCredential%2C%20for%20example)%20so%20software%20systems%20can%20more%20easily%20detect%20and%20process%20this%20additional%20information.
       it.skip('All credentials, presentations, and encapsulated objects ' +
         'SHOULD specify, or be associated with, additional more narrow types ' +
         '(like ExampleDegreeCredential, for example) so software systems ' +
         'can more easily detect and process this additional information.',
       async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=All%20credentials%2C%20presentations%2C%20and%20encapsulated%20objects%20SHOULD%20specify%2C%20or%20be%20associated%20with%2C%20additional%20more%20narrow%20types%20(like%20ExampleDegreeCredential%2C%20for%20example)%20so%20software%20systems%20can%20more%20easily%20detect%20and%20process%20this%20additional%20information.`;
         // skipping because SHOULD (not MUST)
       });
     });
@@ -313,10 +313,10 @@ describe('Names and Descriptions', function() {
 
       const fixturePath = './input/names-and-descriptions';
       // On the main credential object itself--as the spec describes
-      // @link https://w3c.github.io/vc-data-model/#names-and-descriptions:~:text=If%20present%2C%20the%20value%20of%20the%20name%20property%20MUST%20be%20a%20string%20or%20a%20language%20value%20object%20as%20described%20in%2011.1%20Language%20and%20Base%20Direction.
       it('If present, the value of the name property MUST be a string or a ' +
         'language value object as described in 11.1 Language and Base ' +
         'Direction.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#names-and-descriptions:~:text=If%20present%2C%20the%20value%20of%20the%20name%20property%20MUST%20be%20a%20string%20or%20a%20language%20value%20object%20as%20described%20in%2011.1%20Language%20and%20Base%20Direction.`;
         await endpoints.issue(require(
           `${fixturePath}/credential-name-ok.json`));
         await endpoints.issue(require(
@@ -330,10 +330,10 @@ describe('Names and Descriptions', function() {
         await assert.rejects(endpoints.issue(require(
           `${fixturePath}/credential-name-extra-prop-en-fail.json`)));
       });
-      // @link https://w3c.github.io/vc-data-model/#names-and-descriptions:~:text=If%20present%2C%20the%20value%20of%20the%20description%20property%20MUST%20be%20a%20string%20or%20a%20language%20value%20object%20as%20described%20in%2011.1%20Language%20and%20Base%20Direction.
       it('If present, the value of the description property MUST be a string ' +
         'or a language value object as described in 11.1 Language and Base ' +
         'Direction.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#names-and-descriptions:~:text=If%20present%2C%20the%20value%20of%20the%20description%20property%20MUST%20be%20a%20string%20or%20a%20language%20value%20object%20as%20described%20in%2011.1%20Language%20and%20Base%20Direction.`;
         await endpoints.issue(require(
           `${fixturePath}/credential-description-ok.json`));
         await endpoints.issue(require(
@@ -350,10 +350,10 @@ describe('Names and Descriptions', function() {
       });
 
       // On `issuer` as in the example at https://w3c.github.io/vc-data-model/#example-usage-of-the-name-and-description-property-0
-      // @link https://w3c.github.io/vc-data-model/#names-and-descriptions:~:text=If%20present%2C%20the%20value%20of%20the%20name%20property%20MUST%20be%20a%20string%20or%20a%20language%20value%20object%20as%20described%20in%2011.1%20Language%20and%20Base%20Direction.
       it('If present (on `issuer`), the value of the name property MUST be a ' +
         'string or a language value object as described in 11.1 Language and ' +
         'Base Direction.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#names-and-descriptions:~:text=If%20present%2C%20the%20value%20of%20the%20name%20property%20MUST%20be%20a%20string%20or%20a%20language%20value%20object%20as%20described%20in%2011.1%20Language%20and%20Base%20Direction.`;
         await endpoints.issue(require(
           `${fixturePath}/issuer-name-ok.json`));
         await endpoints.issue(require(
@@ -367,10 +367,10 @@ describe('Names and Descriptions', function() {
         await assert.rejects(endpoints.issue(require(
           `${fixturePath}/issuer-name-extra-prop-en-fail.json`)));
       });
-      // @link https://w3c.github.io/vc-data-model/#names-and-descriptions:~:text=If%20present%2C%20the%20value%20of%20the%20description%20property%20MUST%20be%20a%20string%20or%20a%20language%20value%20object%20as%20described%20in%2011.1%20Language%20and%20Base%20Direction.
       it('If present (on `issuer`), the value of the description property ' +
         'MUST be a string or a language value object as described in 11.1 ' +
         'Language and Base Direction.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#names-and-descriptions:~:text=If%20present%2C%20the%20value%20of%20the%20description%20property%20MUST%20be%20a%20string%20or%20a%20language%20value%20object%20as%20described%20in%2011.1%20Language%20and%20Base%20Direction.`;
         await endpoints.issue(require(
           `${fixturePath}/issuer-description-ok.json`));
         await endpoints.issue(require(
@@ -398,17 +398,17 @@ describe('Credential Subject', function() {
     describe(name, function() {
       beforeEach(addPerTestMetadata);
 
-      // @link https://w3c.github.io/vc-data-model/#credential-subject:~:text=A%20verifiable%20credential%20MUST%20have%20a%20credentialSubject%20property.
       it('A verifiable credential MUST have a credentialSubject ' +
         'property.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#credential-subject:~:text=A%20verifiable%20credential%20MUST%20have%20a%20credentialSubject%20property.`;
         await assert.rejects(endpoints.issue(require(
           './input/credential-no-subject-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#credential-subject:~:text=The%20value%20of%20the%20credentialSubject%20property%20is%20defined%20as%20a%20set%20of%20objects%20where%20each%20object%20MUST%20be%20the%20subject%20of%20one%20or%20more%20claims%2C%20which%20MUST%20be%20serialized%20inside%20the%20credentialSubject%20property.
       it('The value of the credentialSubject property is defined as a ' +
       'set of objects where each object MUST be the subject of one or more ' +
         'claims, which MUST be serialized inside the credentialSubject ' +
         'property.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#credential-subject:~:text=The%20value%20of%20the%20credentialSubject%20property%20is%20defined%20as%20a%20set%20of%20objects%20where%20each%20object%20MUST%20be%20the%20subject%20of%20one%20or%20more%20claims%2C%20which%20MUST%20be%20serialized%20inside%20the%20credentialSubject%20property.`;
         await assert.rejects(endpoints.issue(require(
           './input/credential-subject-no-claims-fail.json')));
         await endpoints.issue(require(
@@ -430,16 +430,16 @@ describe('Issuer', function() {
     describe(name, function() {
       beforeEach(addPerTestMetadata);
 
-      // @link https://w3c.github.io/vc-data-model/#issuer:~:text=A%20verifiable%20credential%20MUST%20have%20an%20issuer%20property.
       it('A verifiable credential MUST have an issuer property.',
         async function() {
+          this.test.link = `https://w3c.github.io/vc-data-model/#issuer:~:text=A%20verifiable%20credential%20MUST%20have%20an%20issuer%20property.`;
           await assert.rejects(
             endpoints.issue(require('./input/credential-no-issuer-fail.json')));
         });
-      // @link https://w3c.github.io/vc-data-model/#issuer:~:text=The%20value%20of%20the%20issuer%20property%20MUST%20be%20either%20a%20URL%2C%20or%20an%20object%20containing%20an%20id%20property%20whose%20value%20is%20a%20URL
       it('The value of the issuer property MUST be either a URL, or ' +
       'an object containing an id property whose value is a URL.',
       async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#issuer:~:text=The%20value%20of%20the%20issuer%20property%20MUST%20be%20either%20a%20URL%2C%20or%20an%20object%20containing%20an%20id%20property%20whose%20value%20is%20a%20URL`;
         await endpoints.issue(require(
           './input/credential-issuer-object-ok.json'));
         await endpoints.issue(require('./input/credential-issuer-url-ok.json'));
@@ -463,11 +463,11 @@ describe('Validity Period', function() {
     describe(name, function() {
       beforeEach(addPerTestMetadata);
 
-      // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20present%2C%20the%20value%20of%20the%20validFrom%20property%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%20value%20representing%20the%20date%20and%20time%20the%20credential%20becomes%20valid%2C%20which%20could%20be%20a%20date%20and%20time%20in%20the%20future%20or%20in%20the%20past.
       it('If present, the value of the validFrom property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +
         'and time the credential becomes valid, which could be a date and ' +
         'time in the future or in the past.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20present%2C%20the%20value%20of%20the%20validFrom%20property%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%20value%20representing%20the%20date%20and%20time%20the%20credential%20becomes%20valid%2C%20which%20could%20be%20a%20date%20and%20time%20in%20the%20future%20or%20in%20the%20past.`;
         await endpoints.issue(require(
           './input/credential-validfrom-ms-ok.json'));
         await endpoints.issue(require(
@@ -476,11 +476,11 @@ describe('Validity Period', function() {
           './input/credential-validfrom-invalid-fail.json')));
         // TODO: add validFrom in the future test vector.
       });
-      // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20present%2C%20the%20value%20of%20the%20validUntil%20property%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%20value%20representing%20the%20date%20and%20time%20the%20credential%20ceases%20to%20be%20valid%2C%20which%20could%20be%20a%20date%20and%20time%20in%20the%20past%20or%20in%20the%20future
       it('If present, the value of the validUntil property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +
         'and time the credential ceases to be valid, which could be a date ' +
         'and time in the past or in the future.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20present%2C%20the%20value%20of%20the%20validUntil%20property%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%20value%20representing%20the%20date%20and%20time%20the%20credential%20ceases%20to%20be%20valid%2C%20which%20could%20be%20a%20date%20and%20time%20in%20the%20past%20or%20in%20the%20future`;
         await endpoints.issue(require('./input/credential-validuntil-ok.json'));
         await endpoints.issue(require(
           './input/credential-validuntil-ms-ok.json'));
@@ -489,10 +489,10 @@ describe('Validity Period', function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-validuntil-invalid-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validUntil%20value%20also%20exists%2C%20the%20validFrom%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20earlier%20than%20the%20datetime%20expressed%20by%20the%20validUntil%20value.
       it('If a validUntil value also exists, the validFrom value MUST ' +
         'express a datetime that is temporally the same or earlier than the ' +
         'datetime expressed by the validUntil value.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validUntil%20value%20also%20exists%2C%20the%20validFrom%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20earlier%20than%20the%20datetime%20expressed%20by%20the%20validUntil%20value.`;
         const positiveTest = require(
           './input/credential-validUntil-validFrom-ok.json');
         positiveTest.validFrom = createTimeStamp({skew: -2});
@@ -514,10 +514,10 @@ describe('Validity Period', function() {
         }
         assert.rejects(endpoints.verify(result));
       });
-      // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validFrom%20value%20also%20exists%2C%20the%20validUntil%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20later%20than%20the%20datetime%20expressed%20by%20the%20validFrom%20value.
       it('If a validFrom value also exists, the validUntil value MUST ' +
         'express a datetime that is temporally the same or later than the ' +
         'datetime expressed by the validFrom value.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validFrom%20value%20also%20exists%2C%20the%20validUntil%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20later%20than%20the%20datetime%20expressed%20by%20the%20validFrom%20value.`;
         const positiveTest = require(
           './input/credential-validUntil-validFrom-ok.json');
         positiveTest.validFrom = createTimeStamp({skew: -2});
@@ -540,9 +540,9 @@ describe('Validity Period', function() {
         assert.rejects(endpoints.verify(result));
       });
       // 4.8.1 Representing Time https://w3c.github.io/vc-data-model/#representing-time
-      // @link https://w3c.github.io/vc-data-model/#validity-period:~:text=Time%20values%20that%20are%20incorrectly%20serialized%20without%20an%20offset%20MUST%20be%20interpreted%20as%20UTC.
       it.skip('Time values that are incorrectly serialized without an offset ' +
         'MUST be interpreted as UTC.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=Time%20values%20that%20are%20incorrectly%20serialized%20without%20an%20offset%20MUST%20be%20interpreted%20as%20UTC.`;
         // TODO: add test using regular expression from spec.
         // https://w3c.github.io/vc-data-model/#example-regular-expression-to-detect-a-valid-xml-schema-1-1-part-2-datetimestamp
         // eslint-disable-next-line max-len, no-unused-vars
@@ -575,10 +575,10 @@ describe('Securing Mechanisms', function() {
 
       // as of VC 2.0 this means a proof must be attached to an issued VC
       // at least one proof must be on an issued VC
-      // @link https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20document%20MUST%20be%20secured%20by%20at%20least%20one%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.
       it('A conforming document MUST be secured by at least one ' +
         'securing mechanism as described in Section 4.9 Securing Mechanisms.',
       async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20document%20MUST%20be%20secured%20by%20at%20least%20one%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.`;
         // embedded proof test
         should.exist(issuedVc, `Expected ${name} to issue a VC.`);
         should.exist(issuedVc.proof, 'Expected VC to have a proof.');
@@ -593,23 +593,23 @@ describe('Securing Mechanisms', function() {
         }
         // TODO: add enveloped proof test
       });
-      // @link https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20issuer%20implementation%20produces%20conforming%20documents%2C%20MUST%20include%20all%20required%20properties%20in%20the%20conforming%20documents%20that%20it%20produces%2C%20and%20MUST%20secure%20the%20conforming%20documents%20it%20produces%20using%20a%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.
       it('A conforming issuer implementation produces conforming ' +
         'documents, MUST include all required properties in the conforming ' +
         'documents that it produces, and MUST secure the conforming ' +
         'documents it produces using a securing mechanism as described in ' +
         'Section 4.9 Securing Mechanisms.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20issuer%20implementation%20produces%20conforming%20documents%2C%20MUST%20include%20all%20required%20properties%20in%20the%20conforming%20documents%20that%20it%20produces%2C%20and%20MUST%20secure%20the%20conforming%20documents%20it%20produces%20using%20a%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.`;
         should.exist(issuedVc, `Expected ${name} to issue a VC.`);
         should.exist(issuedVc.proof, 'Expected VC to have a proof.');
         // TODO: add enveloped proof test
       });
-      // @link https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20verifier,documents%20are%20detected.
       it('A conforming verifier implementation consumes conforming ' +
       'documents, MUST perform verification on a conforming document as ' +
       'described in Section 4.9 Securing Mechanisms, MUST check that each ' +
       'required property satisfies the normative requirements for that ' +
       'property, and MUST produce errors when non-conforming documents are ' +
       'detected.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20verifier,documents%20are%20detected.`;
         endpoints.verify(issuedVc);
         // should reject a VC without a proof
         assert.rejects(endpoints.verify(require('./input/credential-ok.json')));
@@ -633,9 +633,9 @@ describe('Status', function() {
     describe(name, function() {
       beforeEach(addPerTestMetadata);
 
-      // @link https://w3c.github.io/vc-data-model/#status:~:text=credential%20status%20object.-,If%20present%2C%20the%20normative%20guidance%20in%20Section%204.3%20Identifiers%20MUST%20be%20followed.,-type
       it('If present (credentialStatus.id), the normative guidance ' +
         'in Section 4.3 Identifiers MUST be followed.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#status:~:text=credential%20status%20object.-,If%20present%2C%20the%20normative%20guidance%20in%20Section%204.3%20Identifiers%20MUST%20be%20followed.,-type`;
         // id is optional
         await endpoints.issue(require(
           './input/credential-status-missing-id-ok.json'));
@@ -644,11 +644,11 @@ describe('Status', function() {
         await assert.rejects(endpoints.issue(require(
           './input/credential-status-nonurl-id-fail.json')));
       });
-      // @link https://w3c.github.io/vc-data-model/#status:~:text=The%20type%20property%20is%20REQUIRED.%20It%20is%20used%20to%20express%20the%20type%20of%20status%20information%20expressed%20by%20the%20object.%20The%20related%20normative%20guidance%20in%20Section%204.4%20Types%20MUST%20be%20followed.
       it('(If a credentialStatus property is present), The type ' +
         'property is REQUIRED. It is used to express the type of status ' +
         'information expressed by the object. The related normative ' +
         'guidance in Section 4.4 Types MUST be followed.', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#status:~:text=The%20type%20property%20is%20REQUIRED.%20It%20is%20used%20to%20express%20the%20type%20of%20status%20information%20expressed%20by%20the%20object.%20The%20related%20normative%20guidance%20in%20Section%204.4%20Types%20MUST%20be%20followed.`;
         await assert.rejects(endpoints.issue(require(
           './input/credential-status-missing-type-fail.json')));
         await assert.rejects(endpoints.issue(require(
@@ -656,9 +656,9 @@ describe('Status', function() {
         await endpoints.issue(require(
           './input/credential-status-ok.json'));
       });
-      // @link https://w3c.github.io/vc-data-model/#status:~:text=Status%20schemes%20MUST%20NOT%20be%20implemented%20in%20ways%20that%20enable%20tracking%20of%20individuals
       it.skip('Status schemes MUST NOT be implemented in ways that enable ' +
         'tracking of individuals', async function() {
+        this.test.link = `https://w3c.github.io/vc-data-model/#status:~:text=Status%20schemes%20MUST%20NOT%20be%20implemented%20in%20ways%20that%20enable%20tracking%20of%20individuals`;
         // not testable with automation
       });
 


### PR DESCRIPTION
Once the mocah reporter that supports links is shipped, this will
provide much easier access to everyone looking to relate statements
made in the test suite with claims made in the specification.
