### PR TITLE
Removed invalid issuer field on valid credentials

### DIFF
--- a/tests/input/credential-context-combo1-ok.json
+++ b/tests/input/credential-context-combo1-ok.json
@@ -6,7 +6,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-context-combo2-ok.json
+++ b/tests/input/credential-context-combo2-ok.json
@@ -9,7 +9,6 @@
     "VerifiableCredential",
     "ExampleVerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-context-combo3-fail.json
+++ b/tests/input/credential-context-combo3-fail.json
@@ -6,7 +6,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-context-combo4-fail.json
+++ b/tests/input/credential-context-combo4-fail.json
@@ -6,7 +6,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-evidence-missing-type-fail.json
+++ b/tests/input/credential-evidence-missing-type-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-evidence-ok.json
+++ b/tests/input/credential-evidence-ok.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-evidences-ok.json
+++ b/tests/input/credential-evidences-ok.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-id-nonidentifier-fail.json
+++ b/tests/input/credential-id-nonidentifier-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "id": null,
   "credentialSubject": {
     "id": "did:example:subject"

--- a/tests/input/credential-id-other-ok.json
+++ b/tests/input/credential-id-other-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:other-issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-missing-base-context-fail.json
+++ b/tests/input/credential-missing-base-context-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-missing-required-type-fail.json
+++ b/tests/input/credential-missing-required-type-fail.json
@@ -6,7 +6,6 @@
   "type": [
     "RelationshipCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-multi-id-fail.json
+++ b/tests/input/credential-multi-id-fail.json
@@ -9,7 +9,6 @@
     "https://example.org/credentials/1",
     "https://example.net/credentials/1"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-no-context-fail.json
+++ b/tests/input/credential-no-context-fail.json
@@ -2,7 +2,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-no-subject-fail.json
+++ b/tests/input/credential-no-subject-fail.json
@@ -4,6 +4,5 @@
   ],
   "type": [
     "VerifiableCredential"
-  ],
-  "issuer": "did:example:issuer"
+  ]
 }

--- a/tests/input/credential-no-type-fail.json
+++ b/tests/input/credential-no-type-fail.json
@@ -2,7 +2,6 @@
   "@context": [
     "https://www.w3.org/ns/credentials/v2"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-nonsingle-id-fail.json
+++ b/tests/input/credential-nonsingle-id-fail.json
@@ -9,7 +9,6 @@
     "https://example.org/credentials/1",
     "https://example.com/credentials/2"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-not-url-id-fail.json
+++ b/tests/input/credential-not-url-id-fail.json
@@ -7,7 +7,6 @@
     "VerifiableCredential"
   ],
   "id": "https ://not-a-url/vcs/343cf54b-2c38-480e-b6e8-7302332eae75",
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "name": "id not a url test"
   }

--- a/tests/input/credential-ok.json
+++ b/tests/input/credential-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-optional-type-ok.json
+++ b/tests/input/credential-optional-type-ok.json
@@ -7,7 +7,6 @@
     "VerifiableCredential",
     "RelationshipCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-proof-missing-type-fail.json
+++ b/tests/input/credential-proof-missing-type-fail.json
@@ -4,7 +4,6 @@
     "https://w3id.org/security/suites/ed25519-2020/v1"
   ],
   "type": "VerifiableCredential",
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-proof-ok.json
+++ b/tests/input/credential-proof-ok.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-redef-type-fail.json
+++ b/tests/input/credential-redef-type-fail.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-redef-type2-fail.json
+++ b/tests/input/credential-redef-type2-fail.json
@@ -13,7 +13,6 @@
     "VerifiableCredential",
     "ExampleVerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-refresh-no-id-fail.json
+++ b/tests/input/credential-refresh-no-id-fail.json
@@ -8,7 +8,6 @@
   "refreshService": {
     "type": "https://example.org/#ExampleTestSuiteRefreshService"
   },
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-refresh-no-type-fail.json
+++ b/tests/input/credential-refresh-no-type-fail.json
@@ -8,7 +8,6 @@
   "refreshService": {
     "id": "did:example:refresh/1"
   },
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-refresh-non-url-id-fail.json
+++ b/tests/input/credential-refresh-non-url-id-fail.json
@@ -9,7 +9,6 @@
     "type": "https://example.org/#ExampleTestSuiteRefreshService",
     "id": "https ://not-a-url/8e96ee84-032d-47b2-8d10-86be56032148"
   },
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-refresh-ok.json
+++ b/tests/input/credential-refresh-ok.json
@@ -9,7 +9,6 @@
     "type": "https://example.org/#ExampleTestSuiteRefreshService",
     "id": "did:example:refresh/1"
   },
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-refreshs-ok.json
+++ b/tests/input/credential-refreshs-ok.json
@@ -15,7 +15,6 @@
       "id": "did:example:refresh/3"
     }
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-schema-no-id-fail.json
+++ b/tests/input/credential-schema-no-id-fail.json
@@ -8,7 +8,6 @@
   "credentialSchema": {
     "type": "https://example.org/#ExampleTestSuiteSchema"
   },
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-schema-no-type-fail.json
+++ b/tests/input/credential-schema-no-type-fail.json
@@ -8,7 +8,6 @@
   "credentialSchema": {
     "id": "did:example:schemas/1"
   },
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-schema-non-url-id-fail.json
+++ b/tests/input/credential-schema-non-url-id-fail.json
@@ -9,7 +9,6 @@
     "type": "https://example.org/#ExampleTestSuiteSchema",
     "id": "https ://not-a-url.org/cd28a5c0-a3ca-4057-9e18-074769a54fdb"
   },
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-schema-ok.json
+++ b/tests/input/credential-schema-ok.json
@@ -9,7 +9,6 @@
     "type": "https://example.org/#ExampleTestSuiteSchema",
     "id": "did:example:schemas/1"
   },
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-schemas-ok.json
+++ b/tests/input/credential-schemas-ok.json
@@ -15,7 +15,6 @@
       "id": "did:example:schemas/2"
     }
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-single-id-ok.json
+++ b/tests/input/credential-single-id-ok.json
@@ -7,7 +7,6 @@
     "VerifiableCredential"
   ],
   "id": "https://example.org/credentials/1",
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "description": "A single id test for VC 2.0"
   }

--- a/tests/input/credential-status-missing-id-ok.json
+++ b/tests/input/credential-status-missing-id-ok.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-status-missing-type-fail.json
+++ b/tests/input/credential-status-missing-type-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-status-multiple-id-fail.json
+++ b/tests/input/credential-status-multiple-id-fail.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-status-nonurl-id-fail.json
+++ b/tests/input/credential-status-nonurl-id-fail.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-status-ok.json
+++ b/tests/input/credential-status-ok.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-status-type-nonurl-fail.json
+++ b/tests/input/credential-status-type-nonurl-fail.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-subject-multi-id-fail.json
+++ b/tests/input/credential-subject-multi-id-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": [
       "did:example:subject:one",

--- a/tests/input/credential-subject-multiple-empty-fail.json
+++ b/tests/input/credential-subject-multiple-empty-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": [
     {
       "id": "did:example:subject"

--- a/tests/input/credential-subject-multiple-ok.json
+++ b/tests/input/credential-subject-multiple-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": [
     {
       "id": "did:example:subject"

--- a/tests/input/credential-subject-no-claims-fail.json
+++ b/tests/input/credential-subject-no-claims-fail.json
@@ -5,6 +5,5 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {}
 }

--- a/tests/input/credential-subject-single-id-ok.json
+++ b/tests/input/credential-subject-single-id-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-termsofuse-id-ok.json
+++ b/tests/input/credential-termsofuse-id-ok.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-termsofuse-missing-type-fail.json
+++ b/tests/input/credential-termsofuse-missing-type-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-termsofuse-no-type-fail.json
+++ b/tests/input/credential-termsofuse-no-type-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-termsofuse-ok.json
+++ b/tests/input/credential-termsofuse-ok.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-termsofuses-ok.json
+++ b/tests/input/credential-termsofuses-ok.json
@@ -8,7 +8,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   },

--- a/tests/input/credential-type-mapped-nonurl-fail.json
+++ b/tests/input/credential-type-mapped-nonurl-fail.json
@@ -9,7 +9,6 @@
     "VerifiableCredential",
     "ExampleTestCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-type-mapped-url-ok.json
+++ b/tests/input/credential-type-mapped-url-ok.json
@@ -9,7 +9,6 @@
     "VerifiableCredential",
     "ExampleTestCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-type-unmapped-fail.json
+++ b/tests/input/credential-type-unmapped-fail.json
@@ -7,7 +7,6 @@
     "VerifiableCredential",
     "ExampleTestCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-type-url-ok.json
+++ b/tests/input/credential-type-url-ok.json
@@ -6,7 +6,6 @@
     "VerifiableCredential",
     "https://example.org/#ExampleCredential"
   ],
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-type-urls-order-1-ok.json
+++ b/tests/input/credential-type-urls-order-1-ok.json
@@ -8,7 +8,6 @@
     "VerifiableCredential"
   ],
   "validFrom": "2023-02-23T21:41:38Z",
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-type-urls-order-2-ok.json
+++ b/tests/input/credential-type-urls-order-2-ok.json
@@ -8,7 +8,6 @@
     "https://example.org/#ExampleCredential1"
   ],
   "validFrom": "2023-02-23T21:41:38Z",
-  "issuer": "did:example:issuer",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-validUntil-validFrom-fail.json
+++ b/tests/input/credential-validUntil-validFrom-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "FUTURE DATE",
   "validUntil": "PAST DATE",
   "credentialSubject": {

--- a/tests/input/credential-validUntil-validFrom-ok.json
+++ b/tests/input/credential-validUntil-validFrom-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "PAST DATE",
   "validUntil": "FUTURE DATE",
   "credentialSubject": {

--- a/tests/input/credential-validfrom-invalid-fail.json
+++ b/tests/input/credential-validfrom-invalid-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "Sat 25 Feb 2023 07:16:31 PM CST",
   "credentialSubject": {
     "id": "did:example:subject"

--- a/tests/input/credential-validfrom-ms-ok.json
+++ b/tests/input/credential-validfrom-ms-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "2023-02-26T01:02:58.447Z",
   "credentialSubject": {
     "id": "did:example:subject"

--- a/tests/input/credential-validfrom-tz-ok.json
+++ b/tests/input/credential-validfrom-tz-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "2023-02-25T19:10:39-06:00",
   "credentialSubject": {
     "id": "did:example:subject"

--- a/tests/input/credential-validuntil-invalid-fail.json
+++ b/tests/input/credential-validuntil-invalid-fail.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "2023-02-26T01:21:51Z",
   "validUntil": "Sun, 26 Feb 2023 01:22:14 +0000",
   "credentialSubject": {

--- a/tests/input/credential-validuntil-ms-ok.json
+++ b/tests/input/credential-validuntil-ms-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "2023-02-26T01:20:00Z",
   "validUntil": "2023-02-26T01:20:18.477Z",
   "credentialSubject": {

--- a/tests/input/credential-validuntil-ok.json
+++ b/tests/input/credential-validuntil-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "2023-02-26T01:19:19Z",
   "validUntil": "2023-02-26T01:19:20Z",
   "credentialSubject": {

--- a/tests/input/credential-validuntil-tz-ok.json
+++ b/tests/input/credential-validuntil-tz-ok.json
@@ -5,7 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": "did:example:issuer",
   "validFrom": "2023-02-26T01:21:23Z",
   "validUntil": "2023-02-25T19:21:29-06:00",
   "credentialSubject": {

--- a/tests/input/names-and-descriptions/credential-description-extra-prop-en-fail.json
+++ b/tests/input/names-and-descriptions/credential-description-extra-prop-en-fail.json
@@ -10,9 +10,6 @@
     "@language": "en",
     "url": "did:example:credential"
   },
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-description-language-direction-en-ok.json
+++ b/tests/input/names-and-descriptions/credential-description-language-direction-en-ok.json
@@ -10,9 +10,6 @@
     "@language": "en",
     "@direction": "ltr"
   },
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-description-language-en-ok.json
+++ b/tests/input/names-and-descriptions/credential-description-language-en-ok.json
@@ -9,9 +9,6 @@
     "@value": "An Example Credential",
     "@language": "en"
   },
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-description-ok.json
+++ b/tests/input/names-and-descriptions/credential-description-ok.json
@@ -6,9 +6,6 @@
     "VerifiableCredential"
   ],
   "description": "An Example Credential",
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-description-optional-ok.json
+++ b/tests/input/names-and-descriptions/credential-description-optional-ok.json
@@ -5,9 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-multi-language-description-ok.json
+++ b/tests/input/names-and-descriptions/credential-multi-language-description-ok.json
@@ -15,9 +15,6 @@
     "@value":"Cane",
     "@language": "it"
   }],
-  "issuer": {
-    "id": "did:issuer:dog"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-multi-language-name-ok.json
+++ b/tests/input/names-and-descriptions/credential-multi-language-name-ok.json
@@ -15,9 +15,6 @@
     "@value":"Cane",
     "@language": "it"
   }],
-  "issuer": {
-    "id": "did:issuer:dog"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-name-extra-prop-en-fail.json
+++ b/tests/input/names-and-descriptions/credential-name-extra-prop-en-fail.json
@@ -10,9 +10,6 @@
     "@language": "en",
     "url": "did:example:credential"
   },
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-name-language-direction-en-ok.json
+++ b/tests/input/names-and-descriptions/credential-name-language-direction-en-ok.json
@@ -10,9 +10,6 @@
     "@language": "en",
     "@direction": "ltr"
   },
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-name-language-en-ok.json
+++ b/tests/input/names-and-descriptions/credential-name-language-en-ok.json
@@ -9,9 +9,6 @@
     "@value":"Example Credential",
     "@language": "en"
   },
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-name-ok.json
+++ b/tests/input/names-and-descriptions/credential-name-ok.json
@@ -6,9 +6,6 @@
     "VerifiableCredential"
   ],
   "name": "Example Credential",
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/names-and-descriptions/credential-name-optional-ok.json
+++ b/tests/input/names-and-descriptions/credential-name-optional-ok.json
@@ -5,9 +5,6 @@
   "type": [
     "VerifiableCredential"
   ],
-  "issuer": {
-    "id": "did:example:issuer"
-  },
   "credentialSubject": {
     "id": "did:example:subject"
   }


### PR DESCRIPTION
There is still issues with negative issuer testing, and also testing if the issuer field can be an object.

This fixes the problem where all positive tests would send an invalid issuer.

Problematic tests include:
- Testing if an issuer can be an object
- Testing if an issuer can be a http uri
- Negative testing of empty issuer field
- All description and name issuer tests

