### PR TITLE
Fix missing endpoint

### DIFF
--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -8,82 +8,120 @@ import {
   createRequestBody,
   createVerifyRequestBody
 } from './mock.data.js';
-import {createVp} from './data-generator.js';
+import {
+  createVp
+} from './data-generator.js';
 import http from 'http';
 import receiveJson from './receive-json.js';
 
 export class TestEndpoints {
-  constructor({implementation, tag}) {
-    this.implementation = implementation;
-    this.tag = tag;
-    this.verifier = implementation.verifiers.find(
-      verifier => verifier.tags.has(tag));
-    this.issuer = implementation.issuers.find(
-      issuer => issuer.tags.has(tag));
-    this.vpVerifier = implementation.vpVerifiers.find(
-      vpVerifier => vpVerifier.tags.has(tag));
+  constructor({
+      implementation,
+      tag
+  }) {
+      this.implementation = implementation;
+      this.tag = tag;
+      try {
+          this.verifier = implementation.verifiers.find(
+              verifier => verifier.tags.has(tag));
+      } catch {
+          this.vpVerifier = null;
+      }
+      try {
+          this.issuer = implementation.issuers.find(
+              issuer => issuer.tags.has(tag));
+      } catch {
+          this.vpVerifier = null;
+      }
+      try {
+          this.vpVerifier = implementation.vpVerifiers.find(
+              vpVerifier => vpVerifier.tags.has(tag));
+      } catch {
+          this.vpVerifier = null;
+      }
   }
   async issue(credential) {
-    const {issuer} = this;
-    const issueBody = createRequestBody({issuer, vc: credential});
-    return post(issuer, issueBody);
+      const {
+          issuer
+      } = this;
+      const issueBody = createRequestBody({
+          issuer,
+          vc: credential
+      });
+      var response = await post(issuer, issueBody);
+      return response?.verifiableCredential || response;
   }
-  async createVp({presentation, options = {}}) {
-    return createVp({presentation, options});
+  async createVp({
+      presentation,
+      options = {}
+  }) {
+      return createVp({
+          presentation,
+          options
+      });
   }
   async verify(vc) {
-    const verifyBody = createVerifyRequestBody({vc});
-    const result = await post(this.verifier, verifyBody);
-    if(result?.errors?.length) {
-      throw result.errors[0];
-    }
-    return result;
+      const verifyBody = createVerifyRequestBody({
+          vc
+      });
+      const result = await post(this.verifier, verifyBody);
+      if (result?.errors?.length) {
+          throw result.errors[0];
+      }
+      return result;
   }
-  async verifyVp(vp, options = {checks: []}) {
-    const body = {
-      verifiablePresentation: vp,
-      options
-    };
-    const result = await post(this.vpVerifier, body);
-    if(result?.errors?.length) {
-      throw result.errors[0];
-    }
-    return result;
+  async verifyVp(vp, options = {
+      checks: []
+  }) {
+      const body = {
+          verifiablePresentation: vp,
+          options
+      };
+      const result = await post(this.vpVerifier, body);
+      if (result?.errors?.length) {
+          throw result.errors[0];
+      }
+      return result;
   }
 }
 
 export async function post(endpoint, object) {
   const url = endpoint.settings.endpoint;
-  if(url.startsWith('https:')) {
-    // Use vc-test-suite-implementations for HTTPS requests.
-    const {data, error} = await endpoint.post({json: object});
-    if(error) {
-      throw error;
-    }
-    return data;
+  if (url.startsWith('https:')) {
+      // Use vc-test-suite-implementations for HTTPS requests.
+      const {
+          data,
+          error
+      } = await endpoint.post({
+          json: object
+      });
+      if (error) {
+          throw error;
+      }
+      return data;
   }
   const postData = Buffer.from(JSON.stringify(object));
   const res = await new Promise((resolve, reject) => {
-    const req = http.request(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': postData.length,
-        Accept: 'application/json'
-      }
-    }, resolve);
-    req.on('error', reject);
-    req.end(postData);
+      const req = http.request(url, {
+          method: 'POST',
+          headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': postData.length,
+              Accept: 'application/json'
+          }
+      }, resolve);
+      req.on('error', reject);
+      req.end(postData);
   });
   const result = await receiveJson(res);
-  if(res.statusCode >= 400) {
-    if(result != null && result.errors) {
-      throw new Error(result.errors);
-    }
-    throw new Error(result);
+  if (res.statusCode >= 400) {
+      if (result != null && result.errors) {
+          throw new Error(result.errors);
+      }
+      throw new Error(result);
   }
-  if(res.statusCode >= 300) {
-    throw new Error('Redirect not supported');
+  if (res.statusCode >= 300) {
+      throw new Error('Redirect not supported');
   }
   return result;
 }

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -16,15 +16,12 @@ export class TestEndpoints {
   constructor({implementation, tag}) {
     this.implementation = implementation;
     this.tag = tag;
-    try {this.verifier = implementation.verifiers.find(
-      verifier => verifier.tags.has(tag));
-    } catch {this.verifier = null;}
-    try {this.issuer = implementation.issuers.find(
-      issuer => issuer.tags.has(tag));
-    } catch {this.issuer = null;}
-    try {this.vpVerifier = implementation.vpVerifiers.find(
-        vpVerifier => vpVerifier.tags.has(tag));
-    } catch {this.vpVerifier = null;}
+    this.verifier = implementation.verifiers?.find(
+      verifier => verifier.tags.has(tag)) || null;
+    this.issuer = implementation.issuers?.find(
+      issuer => issuer.tags.has(tag)) || null;
+    this.vpVerifier = implementation.vpVerifiers?.find(
+      vpVerifier => vpVerifier.tags.has(tag)) || null;
   }
   async issue(credential) {
     const {issuer} = this;

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -25,13 +25,13 @@ export class TestEndpoints {
           this.verifier = implementation.verifiers.find(
               verifier => verifier.tags.has(tag));
       } catch {
-          this.vpVerifier = null;
+          this.verifier = null;
       }
       try {
           this.issuer = implementation.issuers.find(
               issuer => issuer.tags.has(tag));
       } catch {
-          this.vpVerifier = null;
+          this.issuer = null;
       }
       try {
           this.vpVerifier = implementation.vpVerifiers.find(
@@ -77,6 +77,9 @@ export class TestEndpoints {
           verifiablePresentation: vp,
           options
       };
+      if (this.vpVerifier === null) {
+        return {};
+      }
       const result = await post(this.vpVerifier, body);
       if (result?.errors?.length) {
           throw result.errors[0];

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -44,7 +44,7 @@ export class TestEndpoints {
   }
   async verifyVp(vp, options = {checks: []}) {
     if (this.vpVerifier === null) {
-      return {};
+      return null;
     }
     const body = {
       verifiablePresentation: vp,

--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -8,123 +8,88 @@ import {
   createRequestBody,
   createVerifyRequestBody
 } from './mock.data.js';
-import {
-  createVp
-} from './data-generator.js';
+import {createVp} from './data-generator.js';
 import http from 'http';
 import receiveJson from './receive-json.js';
 
 export class TestEndpoints {
-  constructor({
-      implementation,
-      tag
-  }) {
-      this.implementation = implementation;
-      this.tag = tag;
-      try {
-          this.verifier = implementation.verifiers.find(
-              verifier => verifier.tags.has(tag));
-      } catch {
-          this.verifier = null;
-      }
-      try {
-          this.issuer = implementation.issuers.find(
-              issuer => issuer.tags.has(tag));
-      } catch {
-          this.issuer = null;
-      }
-      try {
-          this.vpVerifier = implementation.vpVerifiers.find(
-              vpVerifier => vpVerifier.tags.has(tag));
-      } catch {
-          this.vpVerifier = null;
-      }
+  constructor({implementation, tag}) {
+    this.implementation = implementation;
+    this.tag = tag;
+    try {this.verifier = implementation.verifiers.find(
+      verifier => verifier.tags.has(tag));
+    } catch {this.verifier = null;}
+    try {this.issuer = implementation.issuers.find(
+      issuer => issuer.tags.has(tag));
+    } catch {this.issuer = null;}
+    try {this.vpVerifier = implementation.vpVerifiers.find(
+        vpVerifier => vpVerifier.tags.has(tag));
+    } catch {this.vpVerifier = null;}
   }
   async issue(credential) {
-      const {
-          issuer
-      } = this;
-      const issueBody = createRequestBody({
-          issuer,
-          vc: credential
-      });
-      var response = await post(issuer, issueBody);
-      return response?.verifiableCredential || response;
+    const {issuer} = this;
+    const issueBody = createRequestBody({issuer, vc: credential});
+    return post(issuer, issueBody);
   }
-  async createVp({
-      presentation,
-      options = {}
-  }) {
-      return createVp({
-          presentation,
-          options
-      });
+  async createVp({presentation, options = {}}) {
+    return createVp({presentation, options});
   }
   async verify(vc) {
-      const verifyBody = createVerifyRequestBody({
-          vc
-      });
-      const result = await post(this.verifier, verifyBody);
-      if (result?.errors?.length) {
-          throw result.errors[0];
-      }
-      return result;
+    const verifyBody = createVerifyRequestBody({vc});
+    const result = await post(this.verifier, verifyBody);
+    if(result?.errors?.length) {
+      throw result.errors[0];
+    }
+    return result;
   }
-  async verifyVp(vp, options = {
-      checks: []
-  }) {
-      const body = {
-          verifiablePresentation: vp,
-          options
-      };
-      if (this.vpVerifier === null) {
-        return {};
-      }
-      const result = await post(this.vpVerifier, body);
-      if (result?.errors?.length) {
-          throw result.errors[0];
-      }
-      return result;
+  async verifyVp(vp, options = {checks: []}) {
+    if (this.vpVerifier === null) {
+      return {};
+    }
+    const body = {
+      verifiablePresentation: vp,
+      options
+    };
+    const result = await post(this.vpVerifier, body);
+    if(result?.errors?.length) {
+      throw result.errors[0];
+    }
+    return result;
   }
 }
 
 export async function post(endpoint, object) {
   const url = endpoint.settings.endpoint;
-  if (url.startsWith('https:')) {
-      // Use vc-test-suite-implementations for HTTPS requests.
-      const {
-          data,
-          error
-      } = await endpoint.post({
-          json: object
-      });
-      if (error) {
-          throw error;
-      }
-      return data;
+  if(url.startsWith('https:')) {
+    // Use vc-test-suite-implementations for HTTPS requests.
+    const {data, error} = await endpoint.post({json: object});
+    if(error) {
+      throw error;
+    }
+    return data;
   }
   const postData = Buffer.from(JSON.stringify(object));
   const res = await new Promise((resolve, reject) => {
-      const req = http.request(url, {
-          method: 'POST',
-          headers: {
-              'Content-Type': 'application/json',
-              'Content-Length': postData.length,
-              Accept: 'application/json'
-          }
-      }, resolve);
-      req.on('error', reject);
-      req.end(postData);
+    const req = http.request(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': postData.length,
+        Accept: 'application/json'
+      }
+    }, resolve);
+    req.on('error', reject);
+    req.end(postData);
   });
   const result = await receiveJson(res);
-  if (res.statusCode >= 400) {
-      if (result != null && result.errors) {
-          throw new Error(result.errors);
-      }
-      throw new Error(result);
+  if(res.statusCode >= 400) {
+    if(result != null && result.errors) {
+      throw new Error(result.errors);
+    }
+    throw new Error(result);
   }
-  if (res.statusCode >= 300) {
-      throw new Error('Redirect not supported');
+  if(res.statusCode >= 300) {
+    throw new Error('Redirect not supported');
   }
   return result;
 }


### PR DESCRIPTION
Partially addresses #83.

Adds a try catch when fetching implementation endpoints.
Add an if condition if no endpoint is set when conducting a test (this is so the test suite doesn't mark it as passed when the call is rejected)