### PR TITLE
docs(fix): fix markdown link format

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ This file must be a CommonJS module that exports an object containing a
 
 The format of the object contained in the `implementations` array is
 identical to the one defined in
-[the **_Testing locally_** section of VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#testing-locally)).
+[the **_Testing locally_** section of VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#testing-locally).
 The `implementations` array may contain more than one implementation object,
 enabling you to test multiple implementations in one run.
 


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/1fca92c0-f816-4f2e-856d-6d9e0d92afa5)

after:

<img width="942" alt="image" src="https://github.com/user-attachments/assets/118abd8f-8af7-41fc-92bc-45af93b54905">
