### PR TITLE
Resolve some more TODOs.

### DIFF
--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -243,8 +243,8 @@ describe('Types', function() {
         // type mapping to URL: OK
         await assert.doesNotReject(endpoints.issue(require(
           './input/credential-type-mapped-url-ok.json')),
-        'Failed to accept a VC with an additional type defined in the \
-        `@context`.');
+        'Failed to accept a VC with an additional type defined in the ' +
+        '`@context`.');
         // type mapped not to URL: fail
         await assert.rejects(endpoints.issue(require(
           './input/credential-type-mapped-nonurl-fail.json')),
@@ -260,13 +260,13 @@ describe('Types', function() {
         //issue VC with multiple urls in type property
         await assert.doesNotReject(endpoints.issue(require(
           './input/credential-type-urls-order-1-ok.json')),
-        'Failed to accept a VC with different type array ordering (VC type \
-        last).');
+        'Failed to accept a VC with different type array ordering (VC type ' +
+        'last).');
         //issue another VC with same urls in a different order
         await assert.doesNotReject(endpoints.issue(require(
           './input/credential-type-urls-order-2-ok.json')),
-        'Failed to accept a VC with different type array ordering (VC type \
-        middle).');
+        'Failed to accept a VC with different type array ordering (VC type ' +
+        'middle).');
       });
       // Verifiable Credential MUST have a type specified
       it('Verifiable Credential objects MUST have a type specified.',
@@ -551,8 +551,8 @@ describe('Validity Period', function() {
         'Failed to accept a VC using the subtractive timezone format.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-validfrom-invalid-fail.json')),
-        'Failed to reject a VC using an incorrect `validFrom` date-time \
-        format.');
+        'Failed to reject a VC using an incorrect `validFrom` date-time ' +
+        'format.');
         await assert.doesNotReject(endpoints.issue(require(
           './input/credential-validfrom-ms-ok.json')),
         'Failed to accept a VC with a `validFrom` far into the future.');
@@ -573,8 +573,8 @@ describe('Validity Period', function() {
         'Failed to accept a VC using the subtractive timezone format.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-validuntil-invalid-fail.json')),
-        'Failed to reject a VC using an inccorect `validUntil` date-time \
-        format.');
+        'Failed to reject a VC using an inccorect `validUntil` date-time ' +
+        'format.');
       });
       it('If a validUntil value also exists, the validFrom value MUST ' +
         'express a datetime that is temporally the same or earlier than the ' +
@@ -1014,8 +1014,8 @@ describe('Advanced Concepts', function() {
         // `credentialSchema.type`
         await assert.rejects(endpoints.issue(require(
           './input/credential-redef-type-fail.json')),
-        'Failed to reject a VC which redefines the `VerifiableCredential` \
-        type.');
+        'Failed to reject a VC which redefines the `VerifiableCredential` ' +
+        'type.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-redef-type2-fail.json')),
         'Failed to reject a VC containing a redefiled protected term.');

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -11,6 +11,7 @@ import {createRequire} from 'module';
 import {filterByTag} from 'vc-test-suite-implementations';
 import {TestEndpoints} from './TestEndpoints.js';
 
+// eslint-disable-next-line no-unused-vars
 const should = chai.should();
 
 const require = createRequire(import.meta.url);

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -553,7 +553,9 @@ describe('Validity Period', function() {
           './input/credential-validfrom-invalid-fail.json')),
         'Failed to reject a VC using an incorrect `validFrom` date-time \
         format.');
-        // TODO: add validFrom in the future test vector.
+        await assert.doesNotReject(endpoints.issue(require(
+          './input/credential-validfrom-ms-ok.json')),
+        'Failed to accept a VC with a `validFrom` far into the future.');
       });
       it('If present, the value of the validUntil property MUST be an ' +
         '[XMLSCHEMA11-2] dateTimeStamp string value representing the date ' +

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -709,14 +709,15 @@ describe('Securing Mechanisms', function() {
         'property, and MUST produce errors when non-conforming documents are ' +
         'detected.', async function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20verifier,documents%20are%20detected.`;
-        // TODO: this verify is neither awaited nor tested; so just expecting
-        // it to throw? We should be more explicit.
-        endpoints.verify(issuedVc);
+        await assert.doesNotReject(endpoints.verify(issuedVc),
+          'Failed to verify credential.');
         // should reject a VC without a proof
         // TODO: VCs are not required to have a `proof` for verification; they
-        // may be "enveloped" instead.
-        assert.rejects(endpoints.verify(require('./input/credential-ok.json')),
-          'Failed to reject a VC missing a `proof`.');
+        // may be "enveloped" instead. Use test suite tags to determine? or
+        // should we check media types?
+        await assert.rejects(endpoints.verify(
+          require('./input/credential-ok.json')),
+        'Failed to reject a VC missing a `proof`.');
         // TODO: add enveloped proof test
       });
     });

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -673,16 +673,18 @@ describe('Securing Mechanisms', function() {
       async function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20document%20MUST%20be%20secured%20by%20at%20least%20one%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.`;
         // embedded proof test
-        // TODO: confirm these `exist` tests actually work; chaining seems off
-        should.exist(issuedVc, `Expected ${name} to issue a VC.`);
-        should.exist(issuedVc.proof, 'Expected VC to have a proof.');
+        issuedVc.should.have.property('type').that.does
+          .include('VerifiableCredential', `Expected ${name} to issue a VC.`);
+        issuedVc.should.have.property('proof').which.is.not.a('string',
+          'Expected VC to have a `proof`.');
         if(Array.isArray(issuedVc.proof)) {
-          issuedVc.proof.length.should.be.gt(0, 'Expected at least one proof.');
+          issuedVc.proof.length.should.be.gt(0,
+            'Expected at least one `proof`.');
           issuedVc.proof.every(p => typeof p === 'object').should.be.true;
         } else {
           issuedVc.proof.should.be.an(
             'object',
-            'Expected proof to be an object.'
+            'Expected `proof` to be an object.'
           );
         }
         // TODO: add enveloped proof test
@@ -693,8 +695,11 @@ describe('Securing Mechanisms', function() {
         'documents it produces using a securing mechanism as described in ' +
         'Section 4.9 Securing Mechanisms.', async function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#securing-mechanisms:~:text=A%20conforming%20issuer%20implementation%20produces%20conforming%20documents%2C%20MUST%20include%20all%20required%20properties%20in%20the%20conforming%20documents%20that%20it%20produces%2C%20and%20MUST%20secure%20the%20conforming%20documents%20it%20produces%20using%20a%20securing%20mechanism%20as%20described%20in%20Section%204.9%20Securing%20Mechanisms.`;
-        should.exist(issuedVc, `Expected ${name} to issue a VC.`);
-        should.exist(issuedVc.proof, 'Expected VC to have a proof.');
+        // TODO: check "all required properties" (use a shared function)
+        issuedVc.should.have.property('type').that.does
+          .include('VerifiableCredential', `Expected ${name} to issue a VC.`);
+        issuedVc.should.have.property('proof').which.is.not.a('string',
+          'Expected VC to have a `proof`.');
         // TODO: add enveloped proof test
       });
       it('A conforming verifier implementation consumes conforming ' +

--- a/tests/input/credential-validfrom-far-future-ok.json
+++ b/tests/input/credential-validfrom-far-future-ok.json
@@ -1,0 +1,12 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "validFrom": "4023-02-26T01:02:58.447Z",
+  "credentialSubject": {
+    "id": "did:example:subject"
+  }
+}


### PR DESCRIPTION
- Add `validFrom` in the far future test.
- Switch back to + based string concat.
- Use more explicit checks on issued VC.
- Await and assert remaining `proof` tests.
