### PR TITLE
DRY up tests that should be rejected either as issuance or verification.

### DIFF
--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -581,14 +581,14 @@ describe('Validity Period', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validUntil%20value%20also%20exists%2C%20the%20validFrom%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20earlier%20than%20the%20datetime%20expressed%20by%20the%20validUntil%20value.`;
         const positiveTest = require(
           './input/credential-validUntil-validFrom-ok.json');
-        positiveTest.validFrom = createTimeStamp({skew: -2});
-        positiveTest.validUntil = createTimeStamp({skew: 2});
+        positiveTest.validFrom = createTimeStamp({skew: -2000});
+        positiveTest.validUntil = createTimeStamp({skew: 2000});
         await assert.doesNotReject(endpoints.issue(positiveTest),
           'Failed to accept a VC with a `validUntil` after its `validFrom`.');
         const negativeTest = require(
           './input/credential-validUntil-validFrom-fail.json');
-        negativeTest.validFrom = createTimeStamp({skew: 2});
-        negativeTest.validUntil = createTimeStamp({skew: -2});
+        negativeTest.validFrom = createTimeStamp({skew: 2000});
+        negativeTest.validUntil = createTimeStamp({skew: -2000});
         await shouldRejectEitherIssueOrVerify({
           endpoints,
           negativeTest,
@@ -603,14 +603,14 @@ describe('Validity Period', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validFrom%20value%20also%20exists%2C%20the%20validUntil%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20later%20than%20the%20datetime%20expressed%20by%20the%20validFrom%20value.`;
         const positiveTest = require(
           './input/credential-validUntil-validFrom-ok.json');
-        positiveTest.validFrom = createTimeStamp({skew: -2});
-        positiveTest.validUntil = createTimeStamp({skew: 2});
+        positiveTest.validFrom = createTimeStamp({skew: -2000});
+        positiveTest.validUntil = createTimeStamp({skew: 2000});
         await assert.doesNotReject(endpoints.issue(positiveTest),
           'Failed to accept a VC with a `validUntil` after its `validFrom`.');
         const negativeTest = require(
           './input/credential-validUntil-validFrom-fail.json');
-        negativeTest.validFrom = createTimeStamp({skew: 2});
-        negativeTest.validUntil = createTimeStamp({skew: -2});
+        negativeTest.validFrom = createTimeStamp({skew: 2000});
+        negativeTest.validUntil = createTimeStamp({skew: -2000});
         await shouldRejectEitherIssueOrVerify({
           endpoints,
           negativeTest,

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -19,7 +19,6 @@ const baseContextUrl = 'https://www.w3.org/ns/credentials/v2';
 
 const tag = 'vc2.0';
 const {match} = filterByTag({tags: [tag]});
-const oneYear = 1;
 
 function setupMatrix() {
   // this will tell the report
@@ -582,14 +581,14 @@ describe('Validity Period', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validUntil%20value%20also%20exists%2C%20the%20validFrom%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20earlier%20than%20the%20datetime%20expressed%20by%20the%20validUntil%20value.`;
         const positiveTest = require(
           './input/credential-validUntil-validFrom-ok.json');
-        positiveTest.validFrom = createTimeStamp({skew: -1 * oneYear});
-        positiveTest.validUntil = createTimeStamp({skew: oneYear});
+        positiveTest.validFrom = createTimeStamp({skewYears: -1});
+        positiveTest.validUntil = createTimeStamp({skewYears: 1});
         await assert.doesNotReject(endpoints.issue(positiveTest),
           'Failed to accept a VC with a `validUntil` after its `validFrom`.');
         const negativeTest = require(
           './input/credential-validUntil-validFrom-fail.json');
-        negativeTest.validFrom = createTimeStamp({skew: oneYear});
-        negativeTest.validUntil = createTimeStamp({skew: -1 * oneYear});
+        negativeTest.validFrom = createTimeStamp({skewYears: 1});
+        negativeTest.validUntil = createTimeStamp({skewYears: -1});
         await shouldRejectEitherIssueOrVerify({
           endpoints,
           negativeTest,
@@ -604,14 +603,14 @@ describe('Validity Period', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validFrom%20value%20also%20exists%2C%20the%20validUntil%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20later%20than%20the%20datetime%20expressed%20by%20the%20validFrom%20value.`;
         const positiveTest = require(
           './input/credential-validUntil-validFrom-ok.json');
-        positiveTest.validFrom = createTimeStamp({skew: -1 * oneYear});
-        positiveTest.validUntil = createTimeStamp({skew: oneYear});
+        positiveTest.validFrom = createTimeStamp({skewYears: -1});
+        positiveTest.validUntil = createTimeStamp({skewYears: 1});
         await assert.doesNotReject(endpoints.issue(positiveTest),
           'Failed to accept a VC with a `validUntil` after its `validFrom`.');
         const negativeTest = require(
           './input/credential-validUntil-validFrom-fail.json');
-        negativeTest.validFrom = createTimeStamp({skew: oneYear});
-        negativeTest.validUntil = createTimeStamp({skew: -1 * oneYear});
+        negativeTest.validFrom = createTimeStamp({skewYears: 1});
+        negativeTest.validUntil = createTimeStamp({skewYears: -1});
         await shouldRejectEitherIssueOrVerify({
           endpoints,
           negativeTest,

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -19,6 +19,7 @@ const baseContextUrl = 'https://www.w3.org/ns/credentials/v2';
 
 const tag = 'vc2.0';
 const {match} = filterByTag({tags: [tag]});
+const oneYear = 1;
 
 function setupMatrix() {
   // this will tell the report
@@ -581,14 +582,14 @@ describe('Validity Period', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validUntil%20value%20also%20exists%2C%20the%20validFrom%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20earlier%20than%20the%20datetime%20expressed%20by%20the%20validUntil%20value.`;
         const positiveTest = require(
           './input/credential-validUntil-validFrom-ok.json');
-        positiveTest.validFrom = createTimeStamp({skew: -2000});
-        positiveTest.validUntil = createTimeStamp({skew: 2000});
+        positiveTest.validFrom = createTimeStamp({skew: -1 * oneYear});
+        positiveTest.validUntil = createTimeStamp({skew: oneYear});
         await assert.doesNotReject(endpoints.issue(positiveTest),
           'Failed to accept a VC with a `validUntil` after its `validFrom`.');
         const negativeTest = require(
           './input/credential-validUntil-validFrom-fail.json');
-        negativeTest.validFrom = createTimeStamp({skew: 2000});
-        negativeTest.validUntil = createTimeStamp({skew: -2000});
+        negativeTest.validFrom = createTimeStamp({skew: oneYear});
+        negativeTest.validUntil = createTimeStamp({skew: -1 * oneYear});
         await shouldRejectEitherIssueOrVerify({
           endpoints,
           negativeTest,
@@ -603,14 +604,14 @@ describe('Validity Period', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#validity-period:~:text=If%20a%20validFrom%20value%20also%20exists%2C%20the%20validUntil%20value%20MUST%20express%20a%20datetime%20that%20is%20temporally%20the%20same%20or%20later%20than%20the%20datetime%20expressed%20by%20the%20validFrom%20value.`;
         const positiveTest = require(
           './input/credential-validUntil-validFrom-ok.json');
-        positiveTest.validFrom = createTimeStamp({skew: -2000});
-        positiveTest.validUntil = createTimeStamp({skew: 2000});
+        positiveTest.validFrom = createTimeStamp({skew: -1 * oneYear});
+        positiveTest.validUntil = createTimeStamp({skew: oneYear});
         await assert.doesNotReject(endpoints.issue(positiveTest),
           'Failed to accept a VC with a `validUntil` after its `validFrom`.');
         const negativeTest = require(
           './input/credential-validUntil-validFrom-fail.json');
-        negativeTest.validFrom = createTimeStamp({skew: 2000});
-        negativeTest.validUntil = createTimeStamp({skew: -2000});
+        negativeTest.validFrom = createTimeStamp({skew: oneYear});
+        negativeTest.validUntil = createTimeStamp({skew: -1 * oneYear});
         await shouldRejectEitherIssueOrVerify({
           endpoints,
           negativeTest,

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -10,6 +10,7 @@ import chai from 'chai';
 import {createRequire} from 'module';
 import {filterByTag} from 'vc-test-suite-implementations';
 import {TestEndpoints} from './TestEndpoints.js';
+import {shouldRejectEitherIssueOrVerify} from './assertions.js';
 
 const should = chai.should();
 
@@ -588,18 +589,12 @@ describe('Validity Period', function() {
           './input/credential-validUntil-validFrom-fail.json');
         negativeTest.validFrom = createTimeStamp({skew: 2});
         negativeTest.validUntil = createTimeStamp({skew: -2});
-        let error;
-        let result;
-        try {
-          result = await endpoints.issue(negativeTest);
-        } catch(e) {
-          error = e;
-        }
-        if(error) {
-          return;
-        }
-        await assert.rejects(endpoints.verify(result),
-          'Failed to reject a VC with a `validUntil` before its `validFrom`.');
+        await shouldRejectEitherIssueOrVerify({
+          endpoints,
+          negativeTest,
+          reason: 'Failed to reject a VC with a `validUntil` before its ' +
+          '`validFrom`.`'
+        });
       });
       // TODO: the following tests are identical to the above; refactor.
       it('If a validFrom value also exists, the validUntil value MUST ' +
@@ -616,18 +611,12 @@ describe('Validity Period', function() {
           './input/credential-validUntil-validFrom-fail.json');
         negativeTest.validFrom = createTimeStamp({skew: 2});
         negativeTest.validUntil = createTimeStamp({skew: -2});
-        let error;
-        let result;
-        try {
-          result = await endpoints.issue(negativeTest);
-        } catch(e) {
-          error = e;
-        }
-        if(error) {
-          return;
-        }
-        await assert.rejects(endpoints.verify(result),
-          'Failed to reject a VC with a `validUntil` before its `validFrom`.');
+        await shouldRejectEitherIssueOrVerify({
+          endpoints,
+          negativeTest,
+          reason: 'Failed to reject a VC with a `validUntil` before its ' +
+          '`validFrom`.'
+        });
       });
       // 4.8.1 Representing Time https://w3c.github.io/vc-data-model/#representing-time
       it.skip('Time values that are incorrectly serialized without an offset ' +

--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -9,8 +9,8 @@ import assert from 'node:assert/strict';
 import chai from 'chai';
 import {createRequire} from 'module';
 import {filterByTag} from 'vc-test-suite-implementations';
-import {TestEndpoints} from './TestEndpoints.js';
 import {shouldRejectEitherIssueOrVerify} from './assertions.js';
+import {TestEndpoints} from './TestEndpoints.js';
 
 const should = chai.should();
 

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -69,6 +69,8 @@ export function shouldBeIssuedVc({issuedVc}) {
  * @param {object} options.negativeTest - An invalid credential for issuance.
  * @param {string} options.reason - The reason the negativeTest should fail.
  *
+ * @returns {Promise<{error, result}>} Returns the result and error.
+ *
  */
 export async function shouldRejectEitherIssueOrVerify({
   endpoints,
@@ -86,12 +88,13 @@ export async function shouldRejectEitherIssueOrVerify({
   // if an issuer fails to issue a VC with invalid validFrom
   // and/or validUntil we count this as a success and return early
   if(error) {
-    return;
+    return {error, result};
   }
   // if an issuer does not validate validFrom and/or validUntil
   // expect the verifier to reject invalid validFrom and/or
   // validUntil values
   await assert.rejects(endpoints.verify(result), reason);
+  return {error, result};
 }
 
 function _shouldBeValidCredentialSubject({credentialSubject}) {

--- a/tests/data-generator.js
+++ b/tests/data-generator.js
@@ -93,8 +93,8 @@ export async function createVp({presentation, options = {}}) {
   });
 }
 
-export function createTimeStamp({date = new Date(), skew = 0}) {
-  date.setFullYear(date.getFullYear() + skew);
+export function createTimeStamp({date = new Date(), skewYears = 0}) {
+  date.setFullYear(date.getFullYear() + skewYears);
   const isoString = date.toISOString();
   return `${isoString.substring(0, isoString.length - 5)}Z`;
 }


### PR DESCRIPTION
DRY up a pattern used to test if a invalid valid vc is rejected as issuance or verification
Comment said pattern for better understanding.
change magic number for time stamp skew to `oneYear`

p.s. this is a duplicate call on the issuer and verifier so we might consider doing the call once and awaiting the promise twice.