### PR TITLE
Add issuer null check to mock data request builder

### DIFF
--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -13,7 +13,7 @@ const validVc = require('./validVc.json');
 export const createRequestBody = ({issuer, vc = validVc}) => {
   const {settings: {id, options}} = issuer;
   const credential = klona(vc);
-  if(typeof credential.issuer === 'object') {
+  if(credential.issuer !== null && typeof credential.issuer === 'object') {
     if(!('id' in credential.issuer && credential.issuer.id === null)) {
       credential.issuer.id = credential.issuer?.id || id;
     }


### PR DESCRIPTION
Closes #115

- Adds null check to credential issuer before doing `'id' in credential.issuer` check.