### PR TITLE
Remove strict name validation on assert.rejects statements

### DIFF
--- a/tests/1-3-conformance.js
+++ b/tests/1-3-conformance.js
@@ -84,9 +84,9 @@ describe('Basic Conformance', function() {
         const doc = {
           type: ['NonconformingDocument']
         };
-        await assert.rejects(endpoints.verify(doc), {name: 'HTTPError'},
+        await assert.rejects(endpoints.verify(doc),
           'Failed to reject malformed VC.');
-        await assert.rejects(endpoints.verifyVp(doc), {name: 'HTTPError'},
+        await assert.rejects(endpoints.verifyVp(doc),
           'Failed to reject malformed VP.');
       });
     });

--- a/tests/4-3-contexts.js
+++ b/tests/4-3-contexts.js
@@ -87,7 +87,7 @@ describe('Contexts', function() {
           presentation: require('./input/presentation-context-order-fail.json')
         });
         await assert.rejects(endpoints.verifyVp(vpInvalidContextOrder),
-          {name: 'HTTPError'},
+
           'Failed to reject a VP that has the wrong context order.');
         const vp = createLocalVp({
           presentation: require('./input/presentation-ok.json')
@@ -100,7 +100,7 @@ describe('Contexts', function() {
           'Failed to reject a VP with unordered @context.');
         await assert.rejects(endpoints.verifyVp(
           require('./input/presentation-missing-base-context-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VP that lacked the VC base context URL.');
       });
       it('Verifiable Credential `@context`: "Subsequent items in the ' +
@@ -116,11 +116,11 @@ describe('Contexts', function() {
         'Failed to support objects in the `@context` Array.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-context-combo3-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with an invalid `@context` URL.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-context-combo4-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with an unsupported `@context` value type ' +
         '(number).');
       });

--- a/tests/4-4-identifiers.js
+++ b/tests/4-4-identifiers.js
@@ -37,7 +37,7 @@ describe('Identifiers', function() {
         await assert.rejects(
           endpoints.issue(require(
             './input/credential-id-nonidentifier-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a credential with a `null` identifier.');
 
         await assert.doesNotReject(endpoints.issue(require(
@@ -48,16 +48,16 @@ describe('Identifiers', function() {
         'Failed to accept a VC with a valid credentialSubject identifier');
         await assert.rejects(endpoints.issue(require(
           './input/credential-id-multi-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with multiple `id` values.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-id-subject-multi-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with multiple credentialSubject identifiers.');
 
         await assert.rejects(
           endpoints.issue(require('./input/credential-id-not-url-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a credential with an invalid identifier.');
       });
     });

--- a/tests/4-5-types.js
+++ b/tests/4-5-types.js
@@ -34,7 +34,7 @@ describe('Types', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20contain%20a%20type%20property%20with%20an%20associated%20value.`;
         await assert.rejects(
           endpoints.issue(require('./input/credential-no-type-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a VC without a type.');
       });
       it('Verifiable presentations MUST contain a type property with an ' +
@@ -42,7 +42,7 @@ describe('Types', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#types:~:text=Verifiable%20credentials%20and%20verifiable%20presentations%20MUST%20contain%20a%20type%20property%20with%20an%20associated%20value.`;
         await assert.rejects(endpoints.verifyVp(require(
           './input/presentation-no-type-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VP without a type.');
       });
       it('The value of the type property MUST be one or more terms and/or ' +
@@ -61,12 +61,12 @@ describe('Types', function() {
         // type mapped not to URL: fail
         await assert.rejects(endpoints.issue(require(
           './input/credential-type-mapped-nonurl-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with type mapped to an invalid URL.');
         // type not mapped: fail
         await assert.rejects(endpoints.issue(require(
           './input/credential-type-unmapped-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with an unmapped (via `@context`) type.');
       });
       it('If more than one (type) value is provided, the order does not ' +
@@ -92,7 +92,7 @@ describe('Types', function() {
           'Failed to accept a VC with additional type.');
           await assert.rejects(endpoints.issue(require(
             './input/credential-missing-required-type-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a VC missing the `VerifiableCredential` type.');
         }
       );
@@ -109,7 +109,7 @@ describe('Types', function() {
           await assert.rejects(
             endpoints.verifyVp(require(
               './input/presentation-missing-required-type-fail.json')),
-            {name: 'HTTPError'},
+
             'Failed to reject VP missing `VerifiableCredential` type.');
         }
       );
@@ -122,7 +122,7 @@ describe('Types', function() {
           'Failed to accept a VC with `credentialStatus` with a `type`.');
           await assert.rejects(endpoints.issue(require(
             './input/credential-status-missing-type-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a VC with `credentialStatus` without a `type`.');
         }
       );
@@ -135,7 +135,7 @@ describe('Types', function() {
           'Failed to accept a VC with `termsOfUse` with a `type`.');
           await assert.rejects(endpoints.issue(require(
             './input/credential-termsofuse-missing-type-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a VC with `termsOfUse` without a `type`.');
         }
       );
@@ -148,7 +148,7 @@ describe('Types', function() {
           'Failed to accept a VC with `evidence` with a `type`.');
           await assert.rejects(endpoints.issue(require(
             './input/credential-evidence-missing-type-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a VC with `evidence` without a `type`.');
         }
       );
@@ -160,7 +160,7 @@ describe('Types', function() {
           'Failed to accept a VC with `refreshService` with a `type`.');
           await assert.rejects(endpoints.issue(require(
             './input/credential-refresh-no-type-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a VC with `refreshService` without a `type`.');
         }
       );
@@ -172,7 +172,7 @@ describe('Types', function() {
           'Failed to accept a VC with `credentialSchema` with a `type`.');
           await assert.rejects(endpoints.issue(require(
             './input/credential-schema-no-type-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject `credentialSchema` without a `type`.');
         }
       );

--- a/tests/4-6-names-and-descriptions.js
+++ b/tests/4-6-names-and-descriptions.js
@@ -63,7 +63,7 @@ describe('Names and Descriptions', function() {
         'Failed to accept a VC with `name` in multiple languages.');
         await assert.rejects(endpoints.issue(require(
           `${fixturePath}/credential-name-extra-prop-en-fail.json`)),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with `name` containing extra properties.');
       });
       it('If present, the value of the description property MUST be a string ' +
@@ -89,7 +89,7 @@ describe('Names and Descriptions', function() {
         'Failed to accept a VC with `description` in multiple languages.');
         await assert.rejects(endpoints.issue(require(
           `${fixturePath}/credential-description-extra-prop-en-fail.json`)),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with `description` containing extra ' +
         'properties.');
       });
@@ -117,7 +117,7 @@ describe('Names and Descriptions', function() {
         'Failed to accept a VC with `issuer.name` in multiple languages.');
         await assert.rejects(endpoints.issue(require(
           `${fixturePath}/issuer-name-extra-prop-en-fail.json`)),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with `issuer.name` containing extra ' +
         'properties.');
       });
@@ -146,7 +146,7 @@ describe('Names and Descriptions', function() {
         'languages.');
         await assert.rejects(endpoints.issue(require(
           `${fixturePath}/issuer-description-extra-prop-en-fail.json`)),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with `issuer.description` containing extra ' +
         'properties.');
       });

--- a/tests/4-7-issuer.js
+++ b/tests/4-7-issuer.js
@@ -43,19 +43,19 @@ describe('Issuer', function() {
           './input/credential-issuer-object-ok.json')));
         await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-no-url-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject an issuer identifier that was not a URL.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-null-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a null issuer identifier.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-object-id-null-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject an issuer object containing a null identifier.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-issuer-object-id-no-url-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject an issuer object containing a non-URL identifier.');
       });
     });

--- a/tests/4-8-credential-subject.js
+++ b/tests/4-8-credential-subject.js
@@ -33,7 +33,7 @@ describe('Credential Subject', function() {
           this.test.link = `https://w3c.github.io/vc-data-model/#credential-subject:~:text=A%20verifiable%20credential%20MUST%20contain%20a%20credentialSubject%20property.`;
           await assert.rejects(endpoints.issue(require(
             './input/credential-no-subject-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to rejet a VC without a `credentialSubject`.');
         }
       );
@@ -44,7 +44,7 @@ describe('Credential Subject', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#credential-subject:~:text=The%20value%20of%20the%20credentialSubject%20property%20is%20a%20set%20of%20objects%20where%20each%20object%20MUST%20be%20the%20subject%20of%20one%20or%20more%20claims%2C%20which%20MUST%20be%20serialized%20inside%20the%20credentialSubject%20property.`;
         await assert.rejects(endpoints.issue(require(
           './input/credential-subject-no-claims-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with an empty `credentialSubject`.');
         await assert.doesNotReject(endpoints.issue(require(
           './input/credential-subject-multiple-ok.json')),
@@ -52,7 +52,7 @@ describe('Credential Subject', function() {
         await assert.rejects(
           endpoints.issue(require(
             './input/credential-subject-multiple-empty-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject VC containing an empty `credentialSubject`.');
       });
     });

--- a/tests/4-9-validity-period.js
+++ b/tests/4-9-validity-period.js
@@ -42,7 +42,7 @@ describe('Validity Period', function() {
         'Failed to accept a VC using the subtractive timezone format.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-validfrom-invalid-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC using an incorrect `validFrom` date-time ' +
         'format.');
         await assert.doesNotReject(endpoints.issue(require(
@@ -65,7 +65,7 @@ describe('Validity Period', function() {
         'Failed to accept a VC using the subtractive timezone format.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-validuntil-invalid-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC using an inccorect `validUntil` date-time ' +
         'format.');
       });

--- a/tests/410-status.js
+++ b/tests/410-status.js
@@ -37,11 +37,11 @@ describe('Status', function() {
         'Failed to accept a VC with `credentialStatus` without an `id`.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-status-multiple-id-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with multiple `credentialStatus.id` values.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-status-nonurl-id-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with a non-URL `credentialStatus.id`.');
       });
       it('(If a credentialStatus property is present), The type ' +
@@ -51,11 +51,11 @@ describe('Status', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#status:~:text=The%20type%20property%20is%20REQUIRED.%20It%20is%20used%20to%20express%20the%20type%20of%20status%20information%20expressed%20by%20the%20object.%20The%20related%20normative%20guidance%20in%20Section%204.5%20Types%20MUST%20be%20followed.`;
         await assert.rejects(endpoints.issue(require(
           './input/credential-status-missing-type-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC missing `credentialStatus.type`.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-status-type-nonurl-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with a non-URL `credentialStatus.type`.');
         await assert.doesNotReject(endpoints.issue(require(
           './input/credential-status-ok.json')),

--- a/tests/411-data-schemas.js
+++ b/tests/411-data-schemas.js
@@ -47,15 +47,15 @@ describe('Data Schemas', function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#data-schemas:~:text=Each%20credentialSchema%20MUST%20specify%20its%20type%20(for%20example%2C%20JsonSchema)%2C%20and%20an%20id%20property%20that%20MUST%20be%20a%20URL%20identifying%20the%20schema%20file.`;
         await assert.rejects(endpoints.issue(require(
           './input/credential-schema-no-type-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject `credentialSchema` without a `type`.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-schema-no-id-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject `credentialSchema` without an `id`.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-schema-non-url-id-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject `credentialSchema` with a numerid `id`.');
       });
 

--- a/tests/413-verifiable-presentations.js
+++ b/tests/413-verifiable-presentations.js
@@ -73,7 +73,7 @@ describe('Verifiable Presentations', function() {
         ), 'Failed to verify a valid VP.');
         await assert.rejects(endpoints.verifyVp(require(
           './input/presentation-vc-missing-required-type-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VP containing a VC with no `type` value.');
         await assert.rejects(endpoints.verifyVp(require(
           './input/presentation-vc-as-string-fail.json')),

--- a/tests/413.2-envelopes.js
+++ b/tests/413.2-envelopes.js
@@ -131,7 +131,7 @@ describe('VP - Enveloped Verifiable Presentations', function() {
           await assert.rejects(
             endpoints.verifyVp(require(
               './input/enveloped-presentation-context-fail.json')),
-            {name: 'HTTPError'},
+
             'Failed to reject Enveloped VP missing contexts.');
         }
       });
@@ -148,7 +148,7 @@ describe('VP - Enveloped Verifiable Presentations', function() {
           await assert.rejects(
             endpoints.verifyVp(require(
               './input/enveloped-presentation-id-fail.json')),
-            {name: 'HTTPError'},
+
             'Failed to reject Enveloped VP with an id that is not a data url.');
         }
       });
@@ -163,7 +163,7 @@ describe('VP - Enveloped Verifiable Presentations', function() {
           await assert.rejects(
             endpoints.verifyVp(require(
               './input/enveloped-presentation-type-fail.json')),
-            {name: 'HTTPError'},
+
             'Failed to reject VP w/o type "EnvelopedVerifiablePresentation".');
         }
       });

--- a/tests/50-advanced-concepts.js
+++ b/tests/50-advanced-concepts.js
@@ -42,12 +42,12 @@ describe('Advanced Concepts', function() {
         // `credentialSchema.type`
         await assert.rejects(endpoints.issue(require(
           './input/credential-redef-type-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC which redefines the `VerifiableCredential` ' +
         'type.');
         await assert.rejects(endpoints.issue(require(
           './input/credential-redef-type2-fail.json')),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC containing a redefiled protected term.');
       });
 
@@ -66,7 +66,7 @@ describe('Advanced Concepts', function() {
         await assert.rejects(endpoints.issue(require(
           './input/relatedResource/relatedResource-list-of-strings-fail.json'
         )),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with a relatedResource as an array of strings.');
       });
       it('The identifier for the resource is REQUIRED and conforms to the ' +
@@ -76,7 +76,7 @@ describe('Advanced Concepts', function() {
         await assert.rejects(endpoints.issue(require(
           './input/relatedResource/relatedResource-missing-id-fail.json'
         )),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with a relatedResource with no `id` field.');
       });
       it('Each object associated with relatedResource MUST contain at least ' +
@@ -85,7 +85,7 @@ describe('Advanced Concepts', function() {
         await assert.rejects(endpoints.issue(require(
           './input/relatedResource/relatedResource-no-digest-fail.json'
         )),
-        {name: 'HTTPError'},
+
         'Failed to reject a VC with a relatedResource with no digest info.');
       });
 
@@ -113,7 +113,7 @@ describe('Advanced Concepts', function() {
           // `refreshService` value
           await assert.rejects(endpoints.issue(require(
             './input/credential-refresh-no-type-fail.json')),
-          {name: 'HTTPError'},
+
           'Failed to reject a VC with `refreshService` without a `type`.');
         });
 
@@ -131,8 +131,7 @@ describe('Advanced Concepts', function() {
         'IssuerPolicy, and MAY specify its instance id.', async function() {
         this.test.link = `https://w3c.github.io/vc-data-model/#terms-of-use:~:text=Each%20termsOfUse%20value%20MUST%20specify%20its%20type%2C%20for%20example%2C%20IssuerPolicy%2C%20and%20MAY%20specify%20its%20instance%20id.`;
         await assert.rejects(endpoints.issue(require(
-          './input/credential-termsofuse-no-type-fail.json')),
-        {name: 'HTTPError'});
+          './input/credential-termsofuse-no-type-fail.json')));
         await assert.doesNotReject(endpoints.issue(require(
           './input/credential-termsofuse-id-ok.json')));
       });


### PR DESCRIPTION
I had occurrences where my server was returning a different type of error than what the test suite was expecting (ex: returning an `HTTPException` instead of an `HTTPError`) and marked the test as failed even if my server behaved correctly. I wonder if checking for a specific type of error is too strict of a validation here?