### PR TITLE
Add input capture for allure reporting

### DIFF
--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -9,6 +9,7 @@ import {
   createRequestBody,
   createVerifyRequestBody
 } from './mock.data.js';
+import {addJsonAttachment} from './helpers.js';
 import http from 'http';
 import receiveJson from './receive-json.js';
 
@@ -26,7 +27,10 @@ export class TestEndpoints {
   async issue(credential) {
     const {issuer} = this;
     const issueBody = createRequestBody({issuer, vc: credential});
-    return post(issuer, issueBody);
+    await addJsonAttachment('Request', issueBody);
+    const response = post(issuer, issueBody);
+    await addJsonAttachment('Response', response);
+    return response;
   }
   // FIXME implement createVp for implementation endpoints in the future
   // @see https://w3c-ccg.github.io/vc-api/#create-presentation
@@ -35,10 +39,12 @@ export class TestEndpoints {
   }
   async verify(vc) {
     const verifyBody = createVerifyRequestBody({vc});
+    await addJsonAttachment('Request', verifyBody);
     const result = await post(this.verifier, verifyBody);
     if(result?.errors?.length) {
       throw result.errors[0];
     }
+    await addJsonAttachment('Response', result);
     return result;
   }
   async verifyVp(vp, options = {}) {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,3 +1,6 @@
+import * as allure from 'allure-js-commons';
+import {ContentType} from 'allure-js-commons';
+
 export function setupMatrix(match) {
   // this will tell the report
   // to make an interop matrix with this suite
@@ -35,4 +38,18 @@ export function extractIfEnveloped(input) {
   } else {
     return input;
   }
+}
+
+export async function addJsonAttachment(fileName, content) {
+  try {
+    // Temporarily disable the console log to avoid unnecessary info logs.
+    const consoleLog = console.log;
+    console.log = function() {};
+    await allure.attachment(
+      fileName,
+      JSON.stringify(content, null, 2),
+      ContentType.JSON
+    );
+    console.log = consoleLog;
+  } catch(err) {}
 }


### PR DESCRIPTION
This will capture requests and response sent to the issuer/verifier for every call made, useful for debugging.

To avoid this creating unnecessary noise when running with the db reporter, the console logging is disabled when calling the attachment function.