### PR TITLE
fix: add holder for self-asserted verifiable credential

### DIFF
--- a/tests/input/presentation-context-combo1-ok.json
+++ b/tests/input/presentation-context-combo1-ok.json
@@ -5,6 +5,7 @@
   "type": [
     "VerifiablePresentation"
   ],
+  "holder": "did:key:z6MkpJySvETLnxhQG9DzEdmKJtysBDjuuTeDfUj1uNNCUqcj",
   "verifiableCredential": [
     {
       "@context": [

--- a/tests/input/presentation-context-combo2-ok.json
+++ b/tests/input/presentation-context-combo2-ok.json
@@ -9,6 +9,7 @@
     "VerifiablePresentation",
     "ExampleVerifiablePresentation"
   ],
+  "holder": "did:key:z6MkpJySvETLnxhQG9DzEdmKJtysBDjuuTeDfUj1uNNCUqcj",
   "verifiableCredential": [
     {
       "@context": [


### PR DESCRIPTION
According to spec https://w3c.github.io/vc-data-model/#presentations-including-holder-claims

VP & VC, which are used for this type of test, are self-asserted and should include holder property. 
![image](https://github.com/user-attachments/assets/537f4b4e-ab62-480b-ac4c-9b44a5804eb2)

Also, there is a test case to validate that holder is required for such types of presentations https://github.com/w3c/vc-data-model-2.0-test-suite/blob/main/tests/4.13-verifiable-presentations.js#L133