### PR TITLE
fix: related resource digest

### DIFF
--- a/tests/input/relatedResource/relatedResource-digest-multibase-ok.json
+++ b/tests/input/relatedResource/relatedResource-digest-multibase-ok.json
@@ -9,7 +9,7 @@
     "id": "did:example:subject"
   },
   "relatedResource": [{
-    "id": "https://w3c.github.io/vc-data-model/related-resource.json",
-    "digestMultibase": "uZTQ0MjM1NiAgcmVwb3J0cy9yZWxhdGVkLXJlc291cmNlLmpzb24K"
+    "id": "https://raw.githubusercontent.com/w3c-ccg/vc-examples/bf5b8f9b16a204702ba2de0cfadbd9f86dbe299d/docs/edu/university-degree-verifiable-credential.json",
+    "digestMultibase": "uEiAjCHMnK5-ayOIZLWo_TBoKYVvSAprlkYEjRlm19Cj0uw"
   }]
 }

--- a/tests/input/relatedResource/relatedResource-digest-sri-ok.json
+++ b/tests/input/relatedResource/relatedResource-digest-sri-ok.json
@@ -8,9 +8,10 @@
   "credentialSubject": {
     "id": "did:example:subject"
   },
-  "relatedResource": [{
-    "id": "https://w3c.github.io/vc-data-model/related-resource.json",
-    "digestSRI":
-      "sha256-ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356"
-  }]
+  "relatedResource": [
+    {
+      "id": "https://raw.githubusercontent.com/w3c-ccg/vc-examples/bf5b8f9b16a204702ba2de0cfadbd9f86dbe299d/docs/edu/university-degree-verifiable-credential.json",
+      "digestSRI": "sha256-MIwhzJyufmsjiGS1qP0waCmFb0gKa5ZGBI0ZZtfQo9Ls="
+    }
+  ]
 }

--- a/tests/input/relatedResource/relatedResource-with-mediaType-ok.json
+++ b/tests/input/relatedResource/relatedResource-with-mediaType-ok.json
@@ -8,14 +8,16 @@
   "credentialSubject": {
     "id": "did:example:subject"
   },
-  "relatedResource": [{
-    "id": "https://w3c.github.io/vc-data-model/related-resource.json",
-    "digestMultibase": "uZTQ0MjM1NiAgcmVwb3J0cy9yZWxhdGVkLXJlc291cmNlLmpzb24K",
-    "mediaType": "application/json"
-  },{
-    "id": "https://w3c.github.io/vc-data-model/related-resource.json#",
-    "digestSRI":
-      "sha256-ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356",
-    "mediaType": "application/ld+json"
-  }]
+  "relatedResource": [
+    {
+      "id": "https://raw.githubusercontent.com/w3c-ccg/vc-examples/bf5b8f9b16a204702ba2de0cfadbd9f86dbe299d/docs/edu/university-degree-verifiable-credential.json",
+      "digestMultibase": "uEiAjCHMnK5-ayOIZLWo_TBoKYVvSAprlkYEjRlm19Cj0uw",
+      "mediaType": "application/json"
+    },
+    {
+      "id": "https://raw.githubusercontent.com/w3c-ccg/vc-examples/bf5b8f9b16a204702ba2de0cfadbd9f86dbe299d/docs/edu/university-degree-verifiable-credential.json?q=1",
+      "digestSRI": "sha256-MIwhzJyufmsjiGS1qP0waCmFb0gKa5ZGBI0ZZtfQo9Ls=",
+      "mediaType": "application/ld+json"
+    }
+  ]
 }


### PR DESCRIPTION
https://w3c.github.io/vc-data-model/related-resource.json - was removed, and all success cases for relatedResource integrity tests are failing. 

Instead, I replaced it with a file from the w3c-ccg repo, including the commit hash, so this file cannot be removed or overridden with new content.