### PR TITLE
Update digest and vc api

### DIFF
--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -26,7 +26,8 @@ export class TestEndpoints {
   async issue(credential) {
     const {issuer} = this;
     const issueBody = createRequestBody({issuer, vc: credential});
-    return post(issuer, issueBody);
+    const response = await post(issuer, issueBody);
+    return response?.verifiableCredential || response;
   }
   // FIXME implement createVp for implementation endpoints in the future
   // @see https://w3c-ccg.github.io/vc-api/#create-presentation

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -26,6 +26,6 @@ export const envelopedPresentation = {
 export const relatedResource = {
   id: 'https://www.w3.org/ns/credentials/v2',
   mediaType: 'application/ld+json',
-  digestSRI: 'sha384-NSOcNpmdIVUxIJGvGUoe22FjTWrXiaXlsZ8q6912LdnR3KraQO2n75Ica4wK4Qeg',
+  digestSRI: 'sha384-l/HrjlBCNWyAX91hr6LFV2Y3heB5Tcr6IeE4/Tje8YyzYBM8IhqjHWiWpr8+ZbYU',
   digestMultibase: 'uJKGMkOmFbVJhEfKTduMC2XCyvRAYLjOVmZWwIH1wQ7k',
 };

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -27,5 +27,5 @@ export const relatedResource = {
   id: 'https://www.w3.org/ns/credentials/v2',
   mediaType: 'application/ld+json',
   digestSRI: 'sha384-l/HrjlBCNWyAX91hr6LFV2Y3heB5Tcr6IeE4/Tje8YyzYBM8IhqjHWiWpr8+ZbYU',
-  digestMultibase: 'uJKGMkOmFbVJhEfKTduMC2XCyvRAYLjOVmZWwIH1wQ7k',
+  digestMultibase: 'uEiBZlVztZpfWHgPyslVv6-UwirFoQoRvW1htfx963sknNA',
 };


### PR DESCRIPTION
- Addressing https://github.com/w3c/vc-data-model-2.0-test-suite/issues/160 with the response being able to read `verifiableCredential` response from a VC-API conforming endpoint.

- updating the digests (SRI + Multibase) of vc v2 context for relatedResource tests. Please note my last comment about the Digest SRI non conformance with the SRI spec in the VC-DATA-MODEL examples: https://github.com/w3c/vc-data-model/issues/1570#issuecomment-3136850070. I am not using multiformat in the hash generation in this PR, so in my eyes this is the valid and expected SRI digest.
