### PR TITLE
chore: update deps for Node 20 and resolve npm audit findings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,7 @@ module.exports = {
   },
   rules: {
     'jsdoc/check-examples': 0,
+    'jsdoc/newline-after-description': 'off',
     'max-len': ['error', {ignorePattern: '\\* SPDX-License-Identifier: ',
       ignoreUrls: true}]
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "undici": "^6.24.1",
     "@digitalbazaar/zcap": "^9.0.1",
     "@digitalbazaar/http-client": "^4.3.0",
-    "jsonld-signatures": "^11.6.0",
     "jsonld": "^8.3.3"
   },
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,15 @@
   "engines": {
     "node": ">=18"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5",
+    "diff": "^8.0.3",
+    "undici": "^6.24.1",
+    "@digitalbazaar/zcap": "^9.0.1",
+    "@digitalbazaar/http-client": "^4.3.0",
+    "jsonld-signatures": "^11.6.0",
+    "jsonld": "^8.3.3"
+  },
   "bugs": {
     "url": "https://github.com/w3c/vc-data-model-2.0-test-suite/issues"
   },
@@ -40,15 +49,15 @@
     "@digitalbazaar/ed25519-multikey": "^1.0.1",
     "@digitalbazaar/did-method-key": "^5.2.0",
     "@digitalbazaar/ed25519-signature-2020": "^5.4.0",
-    "@digitalbazaar/ezcap": "^4.1.0",
+    "@digitalbazaar/ezcap": "^4.3.0",
     "@digitalbazaar/eddsa-rdfc-2022-cryptosuite": "^1.1.0",
     "@digitalbazaar/mocha-w3c-interop-reporter": "^1.5.0",
     "@digitalbazaar/vc": "^7.0.0",
     "bnid": "^3.0.0",
     "chai": "^4.3.6",
-    "jsonld-signatures": "^11.3.0",
+    "jsonld-signatures": "^11.6.0",
     "klona": "^2.0.5",
-    "mocha": "^10.0.0",
+    "mocha": "^11.7.5",
     "vc-test-suite-implementations": "github:w3c/vc-test-suite-implementations"
   },
   "devDependencies": {
@@ -56,7 +65,7 @@
     "allure-mocha": "^3.0.3",
     "eslint": "^8.19.0",
     "eslint-config-digitalbazaar": "^4.0.1",
-    "eslint-plugin-jsdoc": "^39.3.3",
+    "eslint-plugin-jsdoc": "^48.11.0",
     "eslint-plugin-unicorn": "^43.0.0"
   },
   "mocha": {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,6 +1,6 @@
 import {challenge} from './fixtures.js';
-import {makeZcapRequest} from './zcapHandler.js';
 import {extractIssuedCredential} from './response.js';
+import {makeZcapRequest} from './zcapHandler.js';
 
 export function setupMatrix(match, columnLabel) {
   // this will tell the report

--- a/tests/response.js
+++ b/tests/response.js
@@ -9,7 +9,7 @@
  * Implementations may return the VC directly, or wrapped as either
  * `verifiableCredential` (VC-API) or `credential` (legacy/alternate).
  *
- * @param {object} data - Parsed JSON response body from POST /credentials/issue.
+ * @param {object} data - Parsed JSON from POST /credentials/issue.
  * @returns {object} The issued verifiable credential.
  */
 export function extractIssuedCredential(data) {


### PR DESCRIPTION
## Summary
- Bump `mocha` to 11.x, `eslint-plugin-jsdoc` to 48.x, `ezcap` and `jsonld-signatures` to current releases
- Add `npm` overrides for transitive packages from `vc-test-suite-implementations` (undici, zcap, diff, serialize-javascript, etc.)
- Disable removed `jsdoc/newline-after-description` rule for compatibility with `eslint-config-digitalbazaar`

## Motivation
`npm install` on Node 20 emits `EBADENGINE` warnings and reported 11 audit vulnerabilities (moderate/high).

## Result
- No `EBADENGINE` warnings on Node 20
- `npm audit` reports **0 vulnerabilities**
- `npm run lint` passes

## Test plan
- [x] `npm install`
- [x] `npm audit` (0 vulnerabilities)
- [x] `npm run lint`
- [ ] `npm test` (requires `localConfig.cjs` and a configured implementation endpoint)


Made with [Cursor](https://cursor.com)