### PR TITLE
fix: refresh relatedResource digests for credentials/v2 context

### DIFF
--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -23,9 +23,15 @@ export const envelopedPresentation = {
   type: 'EnvelopedVerifiablePresentation',
   id: `data:application/vp+jwt,${vp_jwt}`
 };
+// Pre–Feb 2025 digests (July 2024 context bytes); stale after w3c/vc-data-model context
+// updates — https://github.com/w3c/vc-data-model-2.0-test-suite/issues/166
+export const relatedResourceDigestsJuly2024 = {
+  digestSRI: 'sha384-NSOcNpmdIVUxIJGvGUoe22FjTWrXiaXlsZ8q6912LdnR3KraQO2n75Ica4wK4Qeg',
+  digestMultibase: 'uJKGMkOmFbVJhEfKTduMC2XCyvRAYLjOVmZWwIH1wQ7k',
+};
 export const relatedResource = {
   id: 'https://www.w3.org/ns/credentials/v2',
   mediaType: 'application/ld+json',
-  digestSRI: 'sha384-NSOcNpmdIVUxIJGvGUoe22FjTWrXiaXlsZ8q6912LdnR3KraQO2n75Ica4wK4Qeg',
-  digestMultibase: 'uJKGMkOmFbVJhEfKTduMC2XCyvRAYLjOVmZWwIH1wQ7k',
+  digestSRI: 'sha384-l/HrjlBCNWyAX91hr6LFV2Y3heB5Tcr6IeE4/Tje8YyzYBM8IhqjHWiWpr8+ZbYU',
+  digestMultibase: 'uWZVc7WaX1h4D8rJVb-vlMIqxaEKEb1tYbX8fet7JJzQ',
 };


### PR DESCRIPTION
## Summary
Updates active `relatedResource` fixture digests in `tests/fixtures.js` to match the current bytes at `https://www.w3.org/ns/credentials/v2`.

The context file changed in February 2025, so July 2024 digests caused false failures for issuers that verify `relatedResource` content at issuance ([details in #166](https://github.com/w3c/vc-data-model-2.0-test-suite/issues/166)).

Preserves the previous digests as `relatedResourceDigestsJuly2024` for reference.

## Changes
| | `digestSRI` | `digestMultibase` |
|---|-------------|-------------------|
| **Active** (`relatedResource`) | `sha384-l/HrjlBCNWyAX91hr6LFV2Y3heB5Tcr6IeE4/Tje8YyzYBM8IhqjHWiWpr8+ZbYU` | `uWZVc7WaX1h4D8rJVb-vlMIqxaEKEb1tYbX8fet7JJzQ` |
| **Archived** (`relatedResourceDigestsJuly2024`) | `sha384-NSOcNpmdIVUxIJGvGUoe22FjTWrXiaXlsZ8q6912LdnR3KraQO2n75Ica4wK4Qeg` | `uJKGMkOmFbVJhEfKTduMC2XCyvRAYLjOVmZWwIH1wQ7k` |

Wrong-digest negative tests are unchanged.

Fixes #166

## Test plan
- [ ] `npm test` with an implementation that verifies `relatedResource` on issue
- [ ] `5-advanced-concepts.js` positive `relatedResource` passes
- [ ] Wrong-digest negative tests still reject


Made with [Cursor](https://cursor.com)