### PR TITLE
feat: accept credential or verifiableCredential in issue responses

### DIFF
--- a/tests/TestEndpoints.js
+++ b/tests/TestEndpoints.js
@@ -9,6 +9,7 @@ import {
   createRequestBody,
   createVerifyRequestBody
 } from './mock.data.js';
+import {extractIssuedCredential} from './response.js';
 import http from 'http';
 import receiveJson from './receive-json.js';
 
@@ -26,7 +27,7 @@ export class TestEndpoints {
   async issue(credential) {
     const {issuer} = this;
     const issueBody = createRequestBody({issuer, vc: credential});
-    return post(issuer, issueBody);
+    return extractIssuedCredential(await post(issuer, issueBody));
   }
   // FIXME implement createVp for implementation endpoints in the future
   // @see https://w3c-ccg.github.io/vc-api/#create-presentation

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,5 +1,6 @@
 import {challenge} from './fixtures.js';
 import {makeZcapRequest} from './zcapHandler.js';
+import {extractIssuedCredential} from './response.js';
 
 export function setupMatrix(match, columnLabel) {
   // this will tell the report
@@ -49,14 +50,14 @@ export const secureCredential = async ({
   const body = {credential, options};
   if(issuer.settings.zcap) {
     const response = await makeZcapRequest(issuer.settings, body);
-    return response?.data?.verifiableCredential;
+    return extractIssuedCredential(response?.data);
   } else {
     const {data, result, error} = await issuer.post({json: body});
     if(!result || !result.ok) {
       error;
       throw new Error('Request rejected.');
     }
-    return data;
+    return extractIssuedCredential(data);
   }
 };
 

--- a/tests/response.js
+++ b/tests/response.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: LicenseRef-w3c-3-clause-bsd-license-2008 OR LicenseRef-w3c-test-suite-license-2023
+ */
+
+/**
+ * Normalize a VC issue HTTP response body to the issued credential object.
+ * Implementations may return the VC directly, or wrapped as either
+ * `verifiableCredential` (VC-API) or `credential` (legacy/alternate).
+ *
+ * @param {object} data - Parsed JSON response body from POST /credentials/issue.
+ * @returns {object} The issued verifiable credential.
+ */
+export function extractIssuedCredential(data) {
+  if(data == null || typeof data !== 'object') {
+    return data;
+  }
+  if(data.verifiableCredential !== undefined) {
+    return data.verifiableCredential;
+  }
+  if(data.credential !== undefined) {
+    return data.credential;
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary
- Add `extractIssuedCredential()` to normalize `POST /credentials/issue` response bodies
- Accept the issued VC when returned as a top-level object, or wrapped under `verifiableCredential` (VC-API) or `credential`
- Apply normalization in `TestEndpoints.issue()` and `helpers.js` `secureCredential()` for both zcap and non-zcap issuer paths

## Motivation
Some implementations return `{ "verifiableCredential": { ... } }` while others use `{ "credential": { ... } }` or a bare VC. The suite should accept any of these shapes so interoperability testing is not tied to one response envelope.

## Test plan
- [x] `npm run lint` (on branches with updated eslint deps)
- [ ] `npm test` with `localConfig.cjs` against an issuer that returns `verifiableCredential`
- [ ] `npm test` against an issuer that returns `credential` or a bare VC


Made with [Cursor](https://cursor.com)