### PR TITLE
Override uuid to ^11.1.1 to clear npm audit findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "undici": "^6.24.1",
     "@digitalbazaar/zcap": "^9.0.1",
     "@digitalbazaar/http-client": "^4.3.0",
-    "jsonld": "^8.3.3"
+    "jsonld": "^8.3.3",
+    "uuid": "^11.1.1"
   },
   "bugs": {
     "url": "https://github.com/w3c/vc-data-model-2.0-test-suite/issues"


### PR DESCRIPTION
## Summary

Adds a `uuid` override to `package.json` to clear the 4 moderate `npm audit` findings, all stemming from a transitive `uuid@8.3.2`.

`uuid@8.3.2` is pulled in via:
- `@digitalbazaar/mocha-w3c-interop-reporter`
- `vc-test-suite-implementations` → `@digitalbazaar/ezcap`

Both pin `uuid@^8.3.2`, which can't reach a patched release, so `npm audit fix` reports "No fix available." Forcing `uuid` to `^11.1.1` via `overrides` resolves [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) on every path.

`uuid@11` is ESM-only, which is compatible with this ESM-only (`"type": "module"`) suite.

## Verification

- `npm audit` → **0 vulnerabilities** (was 4 moderate)
- `npm ls uuid` → both paths resolve to `uuid@11.1.1`
- `npm run lint` → clean

The full interop test suite was not run end-to-end as it requires configured external VC-API issuer/verifier endpoints. This change only affects a transitive dev/runtime dependency version and does not touch test logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)